### PR TITLE
feat/mali/cmd line args

### DIFF
--- a/src/clarity-frontend/CMakeLists.txt
+++ b/src/clarity-frontend/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(clarityfrontend_stuff clarity_language.cpp typecast.cpp clarity_convert.cpp clarity_grammar.cpp pattern_check.cpp)
+add_library(clarityfrontend_stuff clarity_language.cpp typecast.cpp clarity_convert.cpp clarity_grammar.cpp clarity_convert_literals.cpp pattern_check.cpp)
 target_include_directories(clarityfrontend_stuff
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${CLANG_INCLUDE_DIRS}

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -45,22 +45,47 @@ bool clarity_convertert::convert()
   //  2. Then we populate the context with symbols annotated based on the each AST node, and hence prepare for the GOTO conversion.
 
   if (!src_ast_json.contains(
-        "nodes")) // check json file contains AST nodes as Clarity might change
-    assert(!"JSON file does not contain any AST nodes");
+        "contract_identifier")) // check json file contains expression AST nodes as Clarity might change
+    assert(!"JSON file does not contain any expression AST nodes");
 
+#if 0
+  FIXME : we need to iterate over nodes to find absolute path
   if (
     !src_ast_json.contains(
       "absolutePath")) // check json file contains AST nodes as Clarity might change
     assert(!"JSON file does not contain absolutePath");
-
-  absolute_path = src_ast_json["absolutePath"].get<std::string>();
+    absolute_path = src_ast_json["absolutePath"].get<std::string>();
+#endif
+  
+  
 
   // By now the context should have the symbols of all ESBMC's intrinsics and the dummy main
   // We need to convert Clarity AST nodes to the equivalent symbols and add them to the context
+  nlohmann::json &master_node = src_ast_json;
   nlohmann::json &nodes = src_ast_json["nodes"];
-
-  bool found_contract_def = false;
   size_t index = 0;
+  
+  bool found_contract_def = false;
+
+  if(master_node["contract_identifier"].contains("name"))
+  {  
+    std::string contract_name = master_node["contract_identifier"]["name"];
+    found_contract_def = true;
+     log_debug(
+    "clarity",
+    "@@ Contract : name={},  ...",contract_name
+    );
+  }
+  else
+  {
+    assert (!"AST JSON does not have contract name");
+  }
+
+
+      
+ 
+
+  
   for (nlohmann::json::iterator itr = nodes.begin(); itr != nodes.end();
        ++itr, ++index)
   {

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -24,9 +24,11 @@ public:
     const std::string &_contract_path);
   virtual ~clarity_convertert() = default;
 
+
   bool convert();
 
 protected:
+  bool process_expr_node(nlohmann::json & ast_node); // m-ali
   bool convert_ast_nodes(const nlohmann::json &contract_def);
 
   // conversion functions

--- a/src/clarity-frontend/clarity_convert_literals.cpp
+++ b/src/clarity-frontend/clarity_convert_literals.cpp
@@ -1,0 +1,116 @@
+#include <clarity-frontend/clarity_convert.h>
+#include <util/arith_tools.h>
+#include <util/bitvector.h>
+#include <util/c_types.h>
+#include <util/expr_util.h>
+#include <util/ieee_float.h>
+#include <util/string_constant.h>
+#include <util/std_expr.h>
+
+// Integer literal
+bool clarity_convertert::convert_integer_literal(
+  const nlohmann::json &integer_literal,
+  std::string the_value,
+  exprt &dest)
+{
+  typet type;
+  if (get_type_description(integer_literal, type))
+    return true;
+
+  exprt the_val;
+  // extract the value: unsigned
+  BigInt z_ext_value = string2integer(the_value);
+  the_val = constant_exprt(
+    integer2binary(z_ext_value, bv_width(type)),
+    integer2string(z_ext_value),
+    type);
+
+  dest.swap(the_val);
+  return false;
+}
+
+bool clarity_convertert::convert_bool_literal(
+  const nlohmann::json &bool_literal,
+  std::string the_value,
+  exprt &dest)
+{
+  typet type;
+  if (get_type_description(bool_literal, type))
+    return true;
+
+  assert(type.is_bool());
+
+  if (the_value == "true")
+  {
+    dest = true_exprt();
+    return false;
+  }
+
+  if (the_value == "false")
+  {
+    dest = false_exprt();
+    return false;
+  }
+
+  return true;
+}
+
+// TODO: Character literal
+/**
+ * @brief Converts the string literal to a string_constt
+ * 
+ * @param the_value the value of the literal
+ * @param dest return reference
+ * @return true Only if the function fails
+ * @return false Only if the function successfully converts the literal
+ */
+bool clarity_convertert::convert_string_literal(
+  std::string the_value,
+  exprt &dest)
+{
+  size_t string_size = the_value.size();
+  typet type = array_typet(
+    signed_char_type(),
+    constant_exprt(
+      integer2binary(string_size, bv_width(int_type())),
+      integer2string(string_size),
+      int_type()));
+  // TODO: Handle null terminator byte
+  string_constantt string(the_value, type, string_constantt::k_default);
+  dest.swap(string);
+
+  return false;
+}
+
+/**
+ * convert hex-string to uint constant
+ * @n: the bit width, default 256 (unsignedbv_typet(256))
+*/
+bool clarity_convertert::convert_hex_literal(
+  std::string the_value,
+  exprt &dest,
+  const int n)
+{
+  // remove "0x" prefix
+  if (the_value.length() >= 2)
+    if (the_value.substr(0, 2) == "0x")
+    {
+      the_value.erase(0, 2);
+    }
+
+  typet type;
+  type = unsignedbv_typet(n);
+
+  // e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
+  BigInt hex_addr = string2integer(the_value, 16);
+  exprt the_val;
+  the_val = constant_exprt(
+    integer2binary(hex_addr, bv_width(type)), integer2string(hex_addr), type);
+
+  dest.swap(the_val);
+  return false;
+}
+
+// TODO: Float literal.
+//    - Note: Currently clarity does NOT support floating point data types or fp arithmetic.
+//      Everything is done in fixed-point arithmetic as of clarity compiler v0.8.6.

--- a/src/clarity-frontend/clarity_language.cpp
+++ b/src/clarity-frontend/clarity_language.cpp
@@ -25,10 +25,10 @@ clarity_languaget::clarity_languaget()
   if (!fun.empty())
     func_name = fun;
 
-  std::string sol = config.options.get_option("sol");
+  std::string sol = config.options.get_option("clar");
   if (sol.empty())
   {
-    log_error("Please set the smart contract source file via --sol");
+    log_error("Please set the smart contract source file via --clar");
     abort();
   }
   smart_contract = sol;
@@ -82,21 +82,24 @@ bool clarity_languaget::parse(const std::string &path)
 
   while (getline(ast_json_file_stream, new_line))
   {
-    if (new_line.find(".sol =======") != std::string::npos)
+    // find first instance of ast header
+    if (new_line.find(".clar =======") != std::string::npos)
     {
       break;
     }
   }
   while (getline(ast_json_file_stream, new_line))
   {
-    // file pointer continues from "=== *.sol ==="
-    if (new_line.find(".sol =======") == std::string::npos)
+    // file pointer continues from "=== *.clar ==="
+    // carry on until the end of file, we shouldn't see any other instance of the ast header
+    if (new_line.find(".clar =======") == std::string::npos)
     {
       ast_json_content = ast_json_content + new_line + "\n";
     }
     else
     {
-      assert(!"Unsupported feature: found multiple contracts defined in a single .sol file");
+      // found multiple ast headers
+      assert(!"Unsupported feature: found multiple contracts defined in a single .clar file");
     }
   }
 
@@ -106,6 +109,8 @@ bool clarity_languaget::parse(const std::string &path)
   return false;
 }
 
+
+// ToDo : to review this function 
 bool clarity_languaget::convert_intrinsics(contextt &context)
 {
   clang_c_convertert converter(context, ASTs, "C++");

--- a/src/clarity-frontend/clarity_language.cpp
+++ b/src/clarity-frontend/clarity_language.cpp
@@ -6,7 +6,7 @@ CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 CC_DIAGNOSTIC_POP()
 
 #include <clarity-frontend/clarity_language.h>
-// TODO #include <clarity-frontend/clarity_convert.h>
+#include <clarity-frontend/clarity_convert.h>
 #include <clarity-frontend/clarity_template.h>
 #include <clang-c-frontend/clang_c_main.h>
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
@@ -92,6 +92,7 @@ bool clarity_languaget::parse(const std::string &path)
       break;
     }
   }
+#endif
   while (getline(ast_json_file_stream, new_line))
   {
     // file pointer continues from "=== *.clar ==="
@@ -106,7 +107,7 @@ bool clarity_languaget::parse(const std::string &path)
       assert(!"Unsupported feature: found multiple contracts defined in a single .clar file");
     }
   }
-#endif
+
   // parse explicitly
   src_ast_json = nlohmann::json::parse(ast_json_content);
 
@@ -130,14 +131,12 @@ bool clarity_languaget::typecheck(contextt &context, const std::string &module)
   convert_intrinsics(
     new_context); // Add ESBMC and TACAS intrinsic symbols to the context
 
-#if 0
-  TODO
 
   clarity_convertert converter(
     new_context, src_ast_json, func_name, smart_contract);
   if (converter.convert()) // Add Clarity symbols to the context
     return true;
-#endif
+
 
   // migrate from clang_c_adjust to clang_cpp_adjust
   // for the reason that we need clang_cpp_adjust::adjust_side_effect

--- a/src/clarity-frontend/clarity_template.h
+++ b/src/clarity-frontend/clarity_template.h
@@ -2,6 +2,8 @@
   The template/library for Clarity built-in variables, function and data structure
 */
 
+/* NOT SURE HOW THIS FILE IS CONSUMED */
+
 #include <nlohmann/json.hpp>
 #include <unordered_set>
 

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -26,7 +26,7 @@ static const char *const extensions_cpp[] =
 static const char *const extensions_sol_ast[] = {"solast", nullptr};
 static const char *const extensions_jimple[] = {"jimple", nullptr};
 static const char *const extensions_python[] = {"py", nullptr};
-static const char *const extensions_clarity[] = {"clar", nullptr};
+static const char *const extensions_clarity[] = {"clarast", nullptr};
 
 static const language_desct language_desc_C = {"C", extensions_ansi_c};
 static const language_desct language_desc_CPP = {"C++", extensions_cpp};


### PR DESCRIPTION
- fixes searching for clarity header in ast files

It looks for " .clar =====" string instead of " .sol =====" string.

it assumes there is only one instance of " .clar =====". And throws an error if there are multiple instances.
