### PR TITLE
Basic code skeleton and primitive type conversions

### DIFF
--- a/docs/Pseudocode-for-Reading-AST-F3
+++ b/docs/Pseudocode-for-Reading-AST-F3
@@ -46,6 +46,7 @@ Pseudo code for Reading AST F3
                           - [0] can be a funcion name, which means the following items are function params
                           - [0] can be operator, which means the following items are the operands.
                           - [0] can be "response" which means it will require special handling. Like, it will have two objTypes (sucess type, failure type)
+                          - [0] can be "tuple" and requires special handling
                       [1] type identifer : string //example uint_128
                         - However, if the [0] anything other than a literal type then special handling is needed.
                       [2]  size of identifier
@@ -63,6 +64,7 @@ Pseudo code for Reading AST F3
                               - if [0] is "list" then what follows is the elements of the list as per the size in list objtype node.
                               - if [0] is a a conditional "if" then [1] would be a value node containing expression to test, [2] is "value" node if [1] is true, [3] is "value" if [1] is false
                               - if [0] is a "begin" or "let" then it starts a code_block with one or multiple expressions. each expression is a "value" node.
+                              - if [0] is a "tuple" then [1] will be an object containing "key" : "value" pairs. each value entry against a key is to be read as a "Value" node
                             - [1] to [n] would be the params to the operator or function
 
                   
@@ -77,3 +79,21 @@ Pseudo code for Reading AST F3
 
                 }
 
+==> Special Handling for Optional Types:
+if objtype[0] is "optional" that means objtype[2] would another objtype representing what type of optional value to expect.
+then 
+  if value node is an array 
+  then
+    if value[0] is "some"
+    then 
+      value[1] is the value or an expression that would result in objtype[2] type.
+    else
+      invalid value.
+  else
+    value will be "none" string.
+  
+
+==> Special Handling for Tuple Types:
+objtype[0] = "tuple"
+...[1] will be an object containing keys for members of tuples. each corresponding "value" is an objtype array 
+...[2] will contain the number of keys to expect in the tuple.

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -34,44 +34,45 @@ clarity_convertert::clarity_convertert(
     scope_map({}),
     tgt_func(config.options.get_option("function")),
     tgt_cnt(config.options.get_option("clar_contract"))
-    
+
 {
   std::ifstream in(_contract_path);
   contract_contents.assign(
     (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
 }
 
-
-
 // takes first param as input ast_node, the second param is output param where the node represents the objtype node inside an Ast_node
-void clarity_convertert::get_objtype_node(const nlohmann::json & ast_node, nlohmann::json & objtype_node)
+void clarity_convertert::get_objtype_node(
+  const nlohmann::json &ast_node,
+  nlohmann::json &objtype_node)
 {
   objtype_node = ast_node[1]["objtype"];
 }
 // takes objtype node as input param
-std::string clarity_convertert::get_objtype_type_name(const nlohmann::json & objtype_node)
+std::string
+clarity_convertert::get_objtype_type_name(const nlohmann::json &objtype_node)
 {
   return objtype_node[0];
 }
-std::string clarity_convertert::get_objtype_type_identifier(const nlohmann::json & objtype_node)
+std::string clarity_convertert::get_objtype_type_identifier(
+  const nlohmann::json &objtype_node)
 {
   return objtype_node[1];
 }
-std::string clarity_convertert::get_objtype_type_size(const nlohmann::json & objtype_node)
+std::string
+clarity_convertert::get_objtype_type_size(const nlohmann::json &objtype_node)
 {
   return objtype_node[2];
 }
 
-bool clarity_convertert::process_define_data_var(nlohmann::json & ast_node)
+bool clarity_convertert::process_define_data_var(nlohmann::json &ast_node)
 {
-
   ast_node[0]["nodeType"] = "VariableDeclaration";
 
   return false;
-
 }
 
-bool clarity_convertert::process_define_constant(nlohmann::json & ast_node)
+bool clarity_convertert::process_define_constant(nlohmann::json &ast_node)
 {
   /* CASE 1 : 
    {    "identifier": "fixed",
@@ -85,229 +86,220 @@ bool clarity_convertert::process_define_constant(nlohmann::json & ast_node)
         "value": "fixed constant value"
       }*/
 
-    std::string identifier_name = ast_node[1]["identifier"];
-    int id = ast_node[1]["id"];
-    int start_line = ast_node[1]["span"]["start_line"];
-    int start_column = ast_node[1]["span"]["start_column"];
-    std::string identifier_value = "";
-    std::string type_name = std::string(ast_node[1]["value"].type_name());
+  std::string identifier_name = ast_node[1]["identifier"];
+  int id = ast_node[1]["id"];
+  int start_line = ast_node[1]["span"]["start_line"];
+  int start_column = ast_node[1]["span"]["start_column"];
+  std::string identifier_value = "";
+  std::string type_name = std::string(ast_node[1]["value"].type_name());
 
-   
-   // insert a node type information to be used later in get_expression_t()
-    
-    ast_node[1]["nodeType"] = "VariableDeclaration";
-    // we will add expression type depending on the value node rules in each of the 
-    // following if cases
+  // insert a node type information to be used later in get_expression_t()
 
-    if ( type_name == "string")
-    {
-      ast_node[1]["expressionType"] = "Literal";
-      identifier_value = ast_node[1]["value"];
-      int type_size = 128;
-      // "u10" for uint 10, 10 for int value of 10.
-      if (type_name.find("u"))
-        //type_name = "uint";
-        type_name = "uint_const";
-      else
-        type_name = "int";
+  ast_node[1]["nodeType"] = "VariableDeclaration";
+  // we will add expression type depending on the value node rules in each of the
+  // following if cases
 
-      //insert_dummy_objType(ast_node, type_name , type_size);
-      
-    }
-    else if ( type_name == "number")
-    {
-      ast_node[1]["expressionType"] = "Literal";
-      identifier_value = std::to_string(ast_node[1]["value"].get<double>());
-      // the type could be uint , int , double, float.
-      // 128 represents 128-bit
-      //insert_dummy_objType(ast_node, "uint" , 128);
-    }
-    else if (type_name == "array")
-    {
-      std::cout << " It's a list, so probably a function / operator \n";
-    }
-    else if (type_name == "object")
-    {
-      std::cout << " It's an object, so probably contains lit_ascii \n";
-    }
+  if (type_name == "string")
+  {
+    ast_node[1]["expressionType"] = "Literal";
+    identifier_value = ast_node[1]["value"];
+    int type_size = 128;
+    // "u10" for uint 10, 10 for int value of 10.
+    if (type_name.find("u"))
+      //type_name = "uint";
+      type_name = "uint_const";
     else
-    {
-      identifier_value = "invalid value";
-    }
-    
-    std::cout <<"Constant Definition" <<" of : " <<identifier_name<< " | value : " <<identifier_value<<" found @ "<<start_line<< ":" <<start_column <<"\n";
-    
-                    
+      type_name = "int";
+
+    //insert_dummy_objType(ast_node, type_name , type_size);
+  }
+  else if (type_name == "number")
+  {
+    ast_node[1]["expressionType"] = "Literal";
+    identifier_value = std::to_string(ast_node[1]["value"].get<double>());
+    // the type could be uint , int , double, float.
+    // 128 represents 128-bit
+    //insert_dummy_objType(ast_node, "uint" , 128);
+  }
+  else if (type_name == "array")
+  {
+    std::cout << " It's a list, so probably a function / operator \n";
+  }
+  else if (type_name == "object")
+  {
+    std::cout << " It's an object, so probably contains lit_ascii \n";
+  }
+  else
+  {
+    identifier_value = "invalid value";
+  }
+
+  std::cout << "Constant Definition"
+            << " of : " << identifier_name << " | value : " << identifier_value
+            << " found @ " << start_line << ":" << start_column << "\n";
 
   return false;
-
 }
 
-bool clarity_convertert::process_define_map(nlohmann::json & ast_node)
+bool clarity_convertert::process_define_map(nlohmann::json &ast_node)
 {
   return false;
-
 }
 
-bool clarity_convertert::process_expr_node(nlohmann::json & ast_node)
+bool clarity_convertert::process_expr_node(nlohmann::json &ast_node)
 {
   auto expr = ast_node;
   // process expr node;
-            if (expr["expr"].contains("List"))
+  if (expr["expr"].contains("List"))
+  {
+    // process expression
+    auto vec_expr_list = expr["expr"]["List"];
+
+    // process list
+    for (auto &list_expr : vec_expr_list)
+    {
+      // process each list item
+      if (list_expr.contains("expr"))
+      {
+        auto t_expr = list_expr["expr"];
+
+        if (t_expr.contains("Atom"))
+        {
+          // id will always be an integer.
+          int node_id = list_expr["id"];
+          int start_line = list_expr["span"]["start_line"];
+          int start_column = list_expr["span"]["start_column"];
+          std::string t_expr_type = t_expr["Atom"];
+          std::cout << "Expression of type : " << t_expr_type << " found @ "
+                    << start_line << ":" << start_column << "\n";
+        }
+        else if (t_expr.contains("LiteralValue"))
+        {
+          auto t_expr_literalValue = t_expr["LiteralValue"];
+          std::string t_expr_d_type;  // = t_expr_literalValue.first;
+          std::string t_expr_d_value; // = t_expr_literalValue.second;
+          for (auto &[key, value] : t_expr_literalValue.items())
+          {
+            if (key == "Principal")
             {
-              // process expression
-              auto vec_expr_list = expr["expr"]["List"];
-
-              // process list
-              for (auto &list_expr: vec_expr_list)
+              t_expr_d_type = "Principal_";
+              auto t_principal = t_expr_literalValue["Principal"];
+              for (auto &[principal_key, principal_value] : t_principal.items())
               {
-                // process each list item 
-                if (list_expr.contains("expr"))
-                {
-                  auto t_expr = list_expr["expr"];
-                  
-                  if (t_expr.contains("Atom"))
-                  {
-                      // id will always be an integer.
-                    int node_id = list_expr["id"];  
-                    int start_line = list_expr["span"]["start_line"];
-                    int start_column = list_expr["span"]["start_column"];
-                    std::string t_expr_type = t_expr["Atom"];
-                    std::cout <<"Expression of type : " <<t_expr_type<< " found @ "<<start_line<< ":" <<start_column <<"\n";
-                    
-                  }
-                  else if (t_expr.contains("LiteralValue"))
-                  {
-                    auto t_expr_literalValue = t_expr["LiteralValue"];
-                    std::string t_expr_d_type; // = t_expr_literalValue.first;
-                    std::string t_expr_d_value; // = t_expr_literalValue.second;
-                    for (auto & [key, value]: t_expr_literalValue.items())
-                    {
-                      
-                      if (key == "Principal")
-                      {
-                        t_expr_d_type = "Principal_";
-                        auto t_principal = t_expr_literalValue["Principal"];
-                        for (auto & [principal_key,principal_value]: t_principal.items())
-                        {
-                          t_expr_d_type += principal_key;
-                          t_expr_d_value = "STN" + principal_key;
-                        }
-
-                      }
-                      else
-                      {
-                        t_expr_d_type = key;
-                        t_expr_d_value = value;
-                        
-                      }
-                      std::cout <<"Literal Value : Type " <<key<< " Value "<<value <<"\n";
-
-                    }
-                  }
-                  
-                }
+                t_expr_d_type += principal_key;
+                t_expr_d_value = "STN" + principal_key;
               }
-              std::cout <<"\n--------- \n";
             }
             else
             {
-              std::cout <<"Incomplete expression \n";
+              t_expr_d_type = key;
+              t_expr_d_value = value;
             }
-            return false;
+            std::cout << "Literal Value : Type " << key << " Value " << value
+                      << "\n";
+          }
+        }
+      }
+    }
+    std::cout << "\n--------- \n";
+  }
+  else
+  {
+    std::cout << "Incomplete expression \n";
+  }
+  return false;
 }
-
 
 void clarity_convertert::convert_dummy_uint_literal()
 {
-      
-      typet symbolType = unsignedbv_typet(128);
-      std::string varName = "myVar";
-      std::string varId = "clar:@C@basicDummy@" + varName + "#123";
+  typet symbolType = unsignedbv_typet(128);
+  std::string varName = "myVar";
+  std::string varId = "clar:@C@basicDummy@" + varName + "#123";
 
-      locationt locationBegin;
-      locationBegin.set_line("293");
-      locationBegin.set_file("basicDummy.clar");
+  locationt locationBegin;
+  locationBegin.set_line("293");
+  locationBegin.set_file("basicDummy.clar");
 
-      std::string debugModuleName = locationBegin.file().as_string();
+  std::string debugModuleName = locationBegin.file().as_string();
 
-      symbolt symbol;
-      get_default_symbol(symbol,debugModuleName,symbolType,varName,varId,locationBegin);
+  symbolt symbol;
+  get_default_symbol(
+    symbol, debugModuleName, symbolType, varName, varId, locationBegin);
 
-      bool is_state_var = true;
+  bool is_state_var = true;
 
-      symbol.lvalue = true;
-      symbol.static_lifetime = is_state_var;
-      symbol.file_local = !is_state_var;
-      symbol.is_extern = false;
+  symbol.lvalue = true;
+  symbol.static_lifetime = is_state_var;
+  symbol.file_local = !is_state_var;
+  symbol.is_extern = false;
 
-      symbolt &addedSymbol = *move_symbol_to_context(symbol);
+  symbolt &addedSymbol = *move_symbol_to_context(symbol);
 
-     
-        // unsigned int constant
-        exprt val;
-        convert_unsigned_integer_literal_with_type(symbolType,"23",val);
-      //   BigInt const_value = string2integer("23");
-      //   /*
-        
-      //     constant_exprt constant(
-      //     integer2binary(z_ext_value, 32), // Convert the value to its binary representation
-      //     integer2string(z_ext_value),     // Human-readable string representation of the value
-      //     type                             // The type of the constant
-      // );
-      // */
-      //   val = constant_exprt(integer2binary(const_value,128),integer2string(const_value),symbolType);
-      clarity_gen_typecast(ns, val, symbolType);
-        addedSymbol.value = val;
+  // unsigned int constant
+  exprt val;
+  convert_unsigned_integer_literal_with_type(symbolType, "23", val);
 
+  //   BigInt const_value = string2integer("23");
+  //   /*
 
+  //     constant_exprt constant(
+  //     integer2binary(z_ext_value, 32), // Convert the value to its binary representation
+  //     integer2string(z_ext_value),     // Human-readable string representation of the value
+  //     type                             // The type of the constant
+  // );
+  // */
+  //   val = constant_exprt(integer2binary(const_value,128),integer2string(const_value),symbolType);
+  clarity_gen_typecast(ns, val, symbolType);
+  addedSymbol.value = val;
 
-      {
+  {
+    // Map the following equation : myResult = 23 + 50
 
-       
-       // Map the following equation : myResult = 23 + 50
+    locationt location_begin;
+    location_begin.set_line("393");
+    location_begin.set_file("basicDummy.clar");
+    std::string resultvar_name = "myResult";
+    std::string resultvar_id = "clar:@C@basicDummy@" + resultvar_name + "#333";
 
-      locationt location_begin;
-      location_begin.set_line("393");
-      location_begin.set_file("basicDummy.clar");
-      std::string resultvar_name = "myResult";
-      std::string resultvar_id = "clar:@C@basicDummy@" + resultvar_name + "#333";
-      
-      symbolt result_symbol;
-      
-      get_default_symbol(result_symbol,"basicDummy.clar",signedbv_typet(128),resultvar_name,resultvar_id,location_begin);
-      
-      result_symbol.lvalue = true;
-      result_symbol.static_lifetime = true;
-      result_symbol.file_local = false;
-      result_symbol.is_extern = false;
-    
+    symbolt result_symbol;
 
-      symbolt &addedSymbol = *move_symbol_to_context(result_symbol);
-      BigInt x = 23;
-      BigInt y = 50;
-      constant_exprt arg1 = constant_exprt(x,signedbv_typet(128));
-      constant_exprt arg2 = constant_exprt(y,signedbv_typet(128));
-    
-      plus_exprt addition(arg1,arg2);
+    get_default_symbol(
+      result_symbol,
+      "basicDummy.clar",
+      signedbv_typet(128),
+      resultvar_name,
+      resultvar_id,
+      location_begin);
 
-      clarity_gen_typecast(ns, addition, result_symbol.type);
-      addedSymbol.value = addition;
-      }
-      
-    {
+    result_symbol.lvalue = true;
+    result_symbol.static_lifetime = true;
+    result_symbol.file_local = false;
+    result_symbol.is_extern = false;
 
-        ///////////////
-        // Map the following : variable_sum = myVar + 50
-        // myVar already exists in the symbol table
-        ////////////
+    symbolt &addedSymbol = *move_symbol_to_context(result_symbol);
+    BigInt x = 23;
+    BigInt y = 50;
+    constant_exprt arg1 = constant_exprt(x, signedbv_typet(128));
+    constant_exprt arg2 = constant_exprt(y, signedbv_typet(128));
 
-        // create a symbol to hold LHS
+    plus_exprt addition(arg1, arg2);
 
-        symbolt varSumSymbol;
-        typet varSumType = unsignedbv_typet(128);
-        // a symbol needs the following attribs to be filled
-        /* 
+    clarity_gen_typecast(ns, addition, result_symbol.type);
+    addedSymbol.value = addition;
+  }
+
+  {
+    ///////////////
+    // Map the following : variable_sum = myVar + 50
+    // myVar already exists in the symbol table
+    ////////////
+
+    // create a symbol to hold LHS
+
+    symbolt varSumSymbol;
+    typet varSumType = unsignedbv_typet(128);
+    // a symbol needs the following attribs to be filled
+    /* 
         
         std::string module_name,  //for debug only
         typet type, 
@@ -316,63 +308,63 @@ void clarity_convertert::convert_dummy_uint_literal()
         locationt location)
         */
 
-      
-      std::string varSumName = "varSum";
-      std::string varSumId = "clar:@C@" + current_contractName + "@" + varSumName + "#123";
-      locationt location_begin;
-      location_begin.set_line("393");
-      location_begin.set_file("basicDummy.clar");
+    std::string varSumName = "varSum";
+    std::string varSumId =
+      "clar:@C@" + current_contractName + "@" + varSumName + "#123";
+    locationt location_begin;
+    location_begin.set_line("393");
+    location_begin.set_file("basicDummy.clar");
 
-      get_default_symbol(varSumSymbol,"basicDummy.clar",varSumType,varSumName,varSumId,location_begin);
+    get_default_symbol(
+      varSumSymbol,
+      "basicDummy.clar",
+      varSumType,
+      varSumName,
+      varSumId,
+      location_begin);
 
-      varSumSymbol.lvalue = true;
-      varSumSymbol.static_lifetime = true;
-      varSumSymbol.file_local = false;
-      varSumSymbol.is_extern = false;
+    varSumSymbol.lvalue = true;
+    varSumSymbol.static_lifetime = true;
+    varSumSymbol.file_local = false;
+    varSumSymbol.is_extern = false;
 
-      symbolt &addedSymbol = *move_symbol_to_context(varSumSymbol);
+    symbolt &addedSymbol = *move_symbol_to_context(varSumSymbol);
 
-      //for RHS we need to create an expression
-      // the expression is a binary expression
-      // the first operand is a symbol_exprt
-      // the second operand is a constant_exprt
-      // the operation is a plus_exprt
+    //for RHS we need to create an expression
+    // the expression is a binary expression
+    // the first operand is a symbol_exprt
+    // the second operand is a constant_exprt
+    // the operation is a plus_exprt
 
-      // first, look for the symbol in the symbol table as myVar has been created before
-      // if not found, create a new symbol for myVar
+    // first, look for the symbol in the symbol table as myVar has been created before
+    // if not found, create a new symbol for myVar
 
-      symbolt *myVarSymbol = context.find_symbol(varId);
+    symbolt *myVarSymbol = context.find_symbol(varId);
 
-      // if myVarSymbol is not found, create a new symbol for myVar
-      // skipping this step for now. assuming myVar is already in the symbol table
+    // if myVarSymbol is not found, create a new symbol for myVar
+    // skipping this step for now. assuming myVar is already in the symbol table
 
-      // create a symbol_exprt for myVar
-      symbol_exprt myVarExpr(myVarSymbol->name,varSumType);
-      myVarExpr.identifier(myVarSymbol->id);
+    // create a symbol_exprt for myVar
+    symbol_exprt myVarExpr(myVarSymbol->name, varSumType);
+    myVarExpr.identifier(myVarSymbol->id);
 
-      // create a constant_exprt for 50
-      constant_exprt fifty(50,varSumType);
+    // create a constant_exprt for 50
+    constant_exprt fifty(50, varSumType);
 
-      // write code to use a symbol already in the symbol table to a plus expression
+    // write code to use a symbol already in the symbol table to a plus expression
 
+    // create a plus_exprt for myVar + 50
+    plus_exprt sum(myVarExpr, fifty);
 
+    // typecast the expression
+    clarity_gen_typecast(ns, sum, varSumSymbol.type);
 
-      // create a plus_exprt for myVar + 50
-      plus_exprt sum(myVarExpr, fifty);
+    // assign the expression to the symbol
+    addedSymbol.value = sum;
+  }
 
-      // typecast the expression
-      clarity_gen_typecast(ns, sum, varSumSymbol.type);
-
-      // assign the expression to the symbol
-      addedSymbol.value = sum;
-
-
-       
-
-    }
-
-    {
-      /*
+  {
+    /*
         DEFINING STRUCTS AND USING THEM FOR SYMBOL TYPES
 
         Translate the following :
@@ -387,151 +379,167 @@ void clarity_convertert::convert_dummy_uint_literal()
         
       */
 
-      // Create a struct_typet for the principal struct
-      struct_typet principal_type;
-      std::string struct_name = "principal";
-      std::string struct_id = prefix + "struct " + struct_name;   //tag-struct principal
-      principal_type.tag("struct " + struct_name);
+    // Create a struct_typet for the principal struct
+    struct_typet principal_type;
+    std::string struct_name = "principal";
+    std::string struct_id =
+      prefix + "struct " + struct_name; //tag-struct principal
+    principal_type.tag("struct " + struct_name);
 
-      // Create a symbol for the principal variable
-      symbolt principal_symbol;
+    // Create a symbol for the principal variable
+    symbolt principal_symbol;
 
-      locationt location_begin;
-      location_begin.set_line("444");
-      location_begin.set_file("basicDummy.clar");
+    locationt location_begin;
+    location_begin.set_line("444");
+    location_begin.set_file("basicDummy.clar");
 
-      get_default_symbol(principal_symbol,"basicDummy.clar",principal_type,struct_name,struct_id,location_begin);
-      
-      principal_symbol.is_type = true;
-      //principal_symbol.static_lifetime = true;
+    get_default_symbol(
+      principal_symbol,
+      "basicDummy.clar",
+      principal_type,
+      struct_name,
+      struct_id,
+      location_begin);
 
-      // Add the principal symbol to the symbol table
-      symbolt &addedSymbol = *move_symbol_to_context(principal_symbol);
+    principal_symbol.is_type = true;
+    //principal_symbol.static_lifetime = true;
 
-      // populate the struct with fields
+    // Add the principal symbol to the symbol table
+    symbolt &addedSymbol = *move_symbol_to_context(principal_symbol);
 
-          //define typet to represent strings
-          typet string_type = array_typet(char_type(), from_integer(30, size_type())); // Array of 30 chars
+    // populate the struct with fields
 
-          // Create component types for the name and homeTeam fields
-          {
-            struct_typet::componentt name_field; 
-            std::string name_field_name = "name";
-            std::string name_field_id = "clar:@C@" + current_contractName + "@" + struct_name + "@" + name_field_name + "#123";
+    //define typet to represent strings
+    typet string_type = array_typet(
+      char_type(), from_integer(30, size_type())); // Array of 30 chars
 
-              //exprt new_expr1 ("symbol",string_type);
-              symbol_exprt new_expr1(name_field_name,string_type);
-              //new_expr1.identifier(name_field_id);
-              new_expr1.identifier(name_field_id);
-              new_expr1.name(name_field_name);
-              new_expr1.cmt_lvalue(true);
-              new_expr1.pretty_name(name_field_name);
-              name_field.swap(new_expr1);
-              
-            name_field.id("component");
-            //name_field.type().set("#member_name",name_field_name);    // this is just to represent it in a pretty way. ot has no other implication
+    // Create component types for the name and homeTeam fields
+    {
+      struct_typet::componentt name_field;
+      std::string name_field_name = "name";
+      std::string name_field_id = "clar:@C@" + current_contractName + "@" +
+                                  struct_name + "@" + name_field_name + "#123";
 
-            principal_type.components().push_back(name_field);
-          }
+      //exprt new_expr1 ("symbol",string_type);
+      symbol_exprt new_expr1(name_field_name, string_type);
+      //new_expr1.identifier(name_field_id);
+      new_expr1.identifier(name_field_id);
+      new_expr1.name(name_field_name);
+      new_expr1.cmt_lvalue(true);
+      new_expr1.pretty_name(name_field_name);
+      name_field.swap(new_expr1);
 
-          {
-            struct_typet::componentt home_team; 
-            std::string home_team_name = "homeTeam";
-            std::string home_team_id = "clar:@C@" + current_contractName + "@" + struct_name + "@" + home_team_name + "#123";
+      name_field.id("component");
+      //name_field.type().set("#member_name",name_field_name);    // this is just to represent it in a pretty way. ot has no other implication
 
-              //exprt new_expr1 ("symbol",string_type);
-              symbol_exprt new_expr1(home_team_name,string_type);
-              //new_expr1.identifier(home_team_id);
-              new_expr1.identifier(home_team_id);
-              new_expr1.name(home_team_name);
-              new_expr1.cmt_lvalue(true);
-              new_expr1.pretty_name(home_team_name);
-              home_team.swap(new_expr1);
-              
-            home_team.id("component");
-            //home_team.type().set("#member_name",home_team_name);    // this is just to represent it in a pretty way. ot has no other implication
-
-            principal_type.components().push_back(home_team);
-          }
-      
-      principal_type.location() = location_begin;
-      addedSymbol.type = principal_type;
-
-      //std::cout <<"Name field " <<principal_type.pretty() <<"\n";
-
-
-      // create an instane of the struct principal
-       { 
-        symbolt principal_instance;
-        std::string principal_instance_name = "myPrincipal";
-        std::string principal_instance_id = "clar:@C@" + current_contractName + "@" + principal_instance_name + "#123";
-        std::string principal_struct_id = "tag-struct principal";   //prefix + "struct " + struct_name
-        typet principal_type;
-        
-        if(context.find_symbol(principal_struct_id) != nullptr)
-        {
-          const symbolt* symbol = context.find_symbol(principal_struct_id);
-          principal_type = symbol->type;
-        }
-          
-        else
-          abort();
-
-        locationt principal_instance_location;
-        principal_instance_location.set_line("555");
-        principal_instance_location.set_file("basicDummy.clar");
-
-        get_default_symbol(principal_instance,"basicDummy.clar",principal_type,principal_instance_name,principal_instance_id,principal_instance_location);
-
-        principal_instance.lvalue = true;
-        principal_instance.static_lifetime = true;
-        principal_instance.file_local = false;
-        principal_instance.is_extern = false;
-
-        symbolt &added_principal_instance = *move_symbol_to_context(principal_instance);
-       }
-   
-
+      principal_type.components().push_back(name_field);
     }
 
-      
+    {
+      struct_typet::componentt home_team;
+      std::string home_team_name = "homeTeam";
+      std::string home_team_id = "clar:@C@" + current_contractName + "@" +
+                                 struct_name + "@" + home_team_name + "#123";
+
+      //exprt new_expr1 ("symbol",string_type);
+      symbol_exprt new_expr1(home_team_name, string_type);
+      //new_expr1.identifier(home_team_id);
+      new_expr1.identifier(home_team_id);
+      new_expr1.name(home_team_name);
+      new_expr1.cmt_lvalue(true);
+      new_expr1.pretty_name(home_team_name);
+      home_team.swap(new_expr1);
+
+      home_team.id("component");
+      //home_team.type().set("#member_name",home_team_name);    // this is just to represent it in a pretty way. ot has no other implication
+
+      principal_type.components().push_back(home_team);
+    }
+
+    principal_type.location() = location_begin;
+    addedSymbol.type = principal_type;
+
+    //std::cout <<"Name field " <<principal_type.pretty() <<"\n";
+
+    // create an instane of the struct principal
+    {
+      symbolt principal_instance;
+      std::string principal_instance_name = "myPrincipal";
+      std::string principal_instance_id = "clar:@C@" + current_contractName +
+                                          "@" + principal_instance_name +
+                                          "#123";
+      std::string principal_struct_id =
+        "tag-struct principal"; //prefix + "struct " + struct_name
+      typet principal_type;
+
+      if (context.find_symbol(principal_struct_id) != nullptr)
+      {
+        const symbolt *symbol = context.find_symbol(principal_struct_id);
+        principal_type = symbol->type;
+      }
+
+      else
+        abort();
+
+      locationt principal_instance_location;
+      principal_instance_location.set_line("555");
+      principal_instance_location.set_file("basicDummy.clar");
+
+      get_default_symbol(
+        principal_instance,
+        "basicDummy.clar",
+        principal_type,
+        principal_instance_name,
+        principal_instance_id,
+        principal_instance_location);
+
+      principal_instance.lvalue = true;
+      principal_instance.static_lifetime = true;
+      principal_instance.file_local = false;
+      principal_instance.is_extern = false;
+
+      symbolt &added_principal_instance =
+        *move_symbol_to_context(principal_instance);
+    }
+  }
 }
 
 void clarity_convertert::convert_dummy_string_literal()
 {
- // a string literal in ESBMC is represented as a character array.
-      // a character is an 8-bit value (unsigned 8 bit value).
-      // in ESBMC arrays are represented as array_typet. 
-      // array_type has a subtype of char (unsignedbv(8)).
-      std::string literalValue = "Ali";
-      typet subType = signed_char_type();
-      typet symbolType = array_typet(subType,from_integer(literalValue.length() + 1, size_type()));
-      std::string varName = "myString";
-      std::string varId = "clar:@C@basicDummy@" + varName + "#123";
+  // a string literal in ESBMC is represented as a character array.
+  // a character is an 8-bit value (unsigned 8 bit value).
+  // in ESBMC arrays are represented as array_typet.
+  // array_type has a subtype of char (unsignedbv(8)).
+  std::string literalValue = "Ali";
+  typet subType = signed_char_type();
+  typet symbolType =
+    array_typet(subType, from_integer(literalValue.length() + 1, size_type()));
+  std::string varName = "myString";
+  std::string varId = "clar:@C@basicDummy@" + varName + "#123";
 
-      locationt locationBegin;
-      locationBegin.set_line("293");
-      locationBegin.set_file("basicDummy.clar");
+  locationt locationBegin;
+  locationBegin.set_line("293");
+  locationBegin.set_file("basicDummy.clar");
 
-      std::string debugModuleName = locationBegin.file().as_string();
+  std::string debugModuleName = locationBegin.file().as_string();
 
-      symbolt symbol;
-      get_default_symbol(symbol,debugModuleName,symbolType,varName,varId,locationBegin);
-      bool is_state_var = true;
+  symbolt symbol;
+  get_default_symbol(
+    symbol, debugModuleName, symbolType, varName, varId, locationBegin);
+  bool is_state_var = true;
 
-      symbol.lvalue = true;
-      symbol.static_lifetime = is_state_var;
-      symbol.file_local = !is_state_var;
-      symbol.is_extern = false;
+  symbol.lvalue = true;
+  symbol.static_lifetime = is_state_var;
+  symbol.file_local = !is_state_var;
+  symbol.is_extern = false;
 
-      symbolt &addedSymbol = *move_symbol_to_context(symbol);
+  symbolt &addedSymbol = *move_symbol_to_context(symbol);
 
-        
-        exprt val;
-        convert_string_literal(literalValue,val);
-        
-       clarity_gen_typecast(ns, val, symbolType);
-        addedSymbol.value = val;
+  exprt val;
+  convert_string_literal(literalValue, val);
+
+  clarity_gen_typecast(ns, val, symbolType);
+  addedSymbol.value = val;
 }
 
 #if 0
@@ -705,140 +713,137 @@ void clarity_convertert::add_function_definition_symboltable()
 
 }
 #endif
-  
-
-
 
 void clarity_convertert::add_dummy_builtin_functionCall()
 {
-    std::string literalA = "My name ";
-        std::string literalB = "Fatima ";
-        BigInt outputSize = literalA.length() + literalB.length() + 1;
+  std::string literalA = "My name ";
+  std::string literalB = "Fatima ";
+  BigInt outputSize = literalA.length() + literalB.length() + 1;
 
-        exprt functionExpression;
-        std::string id_var = "c:@string_concat";
-        std::string id_func = "c:@F@string_concat";
+  exprt functionExpression;
+  std::string id_var = "c:@string_concat";
+  std::string id_func = "c:@F@string_concat";
 
-        typet subType = signed_char_type();
-        typet symbolType = array_typet(subType,from_integer(outputSize,size_type()));
-        std::string varName = "myConcat";
-        std::string varId = "clar:@C@basicDummy@" + varName + "#123";
+  typet subType = signed_char_type();
+  typet symbolType =
+    array_typet(subType, from_integer(outputSize, size_type()));
+  std::string varName = "myConcat";
+  std::string varId = "clar:@C@basicDummy@" + varName + "#123";
 
-        locationt locationBegin;
-        locationBegin.set_line("293");
-        locationBegin.set_file("basicDummy.clar");
+  locationt locationBegin;
+  locationBegin.set_line("293");
+  locationBegin.set_file("basicDummy.clar");
 
-        std::string debugModuleName = locationBegin.file().as_string();
+  std::string debugModuleName = locationBegin.file().as_string();
 
-        symbolt symbol;
-        get_default_symbol(symbol,debugModuleName,symbolType,varName,varId,locationBegin);
+  symbolt symbol;
+  get_default_symbol(
+    symbol, debugModuleName, symbolType, varName, varId, locationBegin);
 
-        bool is_state_var = true;
+  bool is_state_var = true;
 
-        symbol.lvalue = true;
-        symbol.static_lifetime = is_state_var;
-        symbol.file_local = !is_state_var;
-        symbol.is_extern = false;
+  symbol.lvalue = true;
+  symbol.static_lifetime = is_state_var;
+  symbol.file_local = !is_state_var;
+  symbol.is_extern = false;
 
-        symbolt &addedSymbol = *move_symbol_to_context(symbol);
+  symbolt &addedSymbol = *move_symbol_to_context(symbol);
 
-        //check if it's already in the symbol table.
-        // it should be, as all builtin functions and blockchain variables
-        // have been pre-defined and added to symbol table during temp_file() creation
+  //check if it's already in the symbol table.
+  // it should be, as all builtin functions and blockchain variables
+  // have been pre-defined and added to symbol table during temp_file() creation
 
+  // 1 - look for the function name in symbol table.
 
-        // 1 - look for the function name in symbol table.
+  // for global blockchain vars like block_height
+  if (context.find_symbol(id_var) != nullptr)
+  {
+    symbolt &sym = *context.find_symbol(id_var);
 
-        // for global blockchain vars like block_height
-        if (context.find_symbol(id_var) != nullptr)
-          {
-            symbolt &sym = *context.find_symbol(id_var);
+    if (sym.value.is_empty() || sym.value.is_zero())
+    {
+      // update: set the value to rand (default 0）
+      // since all the current support built-in vars are uint type.
+      // we just set the value to c:@F@nondet_uint
+      symbolt &r = *context.find_symbol("c:@F@nondet_uint");
+      sym.value = r.value;
+    }
+    functionExpression = symbol_expr(sym);
+  }
 
-            if (sym.value.is_empty() || sym.value.is_zero())
-            {
-              // update: set the value to rand (default 0）
-              // since all the current support built-in vars are uint type.
-              // we just set the value to c:@F@nondet_uint
-              symbolt &r = *context.find_symbol("c:@F@nondet_uint");
-              sym.value = r.value;
-            }
-            functionExpression = symbol_expr(sym);
-          }
+  // for builtin functions like concat.
+  else if (context.find_symbol(id_func) != nullptr)
+    functionExpression = symbol_expr(*context.find_symbol(id_func));
+  else
+  {
+    std::cout << "ALL HELL BROKE LOSE\n";
+    abort();
+  }
 
-          // for builtin functions like concat.
-          else if (context.find_symbol(id_func) != nullptr)
-            functionExpression = symbol_expr(*context.find_symbol(id_func));
-          else
-          {
-              std::cout <<"ALL HELL BROKE LOSE\n";
-              abort();
-          }
+  // ToDo: check validity of functionExpression first.
+  if (functionExpression.is_nil())
+  {
+    std::cout << "Function expression is nil \n";
+    abort();
+  }
 
-         
-            // ToDo: check validity of functionExpression first.
-            if (functionExpression.is_nil())
-            {
-              std:: cout <<"Function expression is nil \n";
-              abort();
-            }
+  // get type of expression: for a function call, the type is the return type
+  //a functioncall is a code_type expression
+  //a function body is a code_t type expression
+  // not to be confused.
 
-            // get type of expression: for a function call, the type is the return type
-            //a functioncall is a code_type expression
-            //a function body is a code_t type expression
-            // not to be confused.
+  typet returnValSymbolType =
+    to_code_type(functionExpression.type()).return_type();
 
-            typet returnValSymbolType = to_code_type(functionExpression.type()).return_type();
+  side_effect_expr_function_callt call;
+  call.function() = functionExpression;
+  call.type() = returnValSymbolType;
 
-            side_effect_expr_function_callt call;
-            call.function() = functionExpression;
-            call.type() = returnValSymbolType;
+  // populate params
 
-            // populate params
+  //find the number of arguments defined in the template (clarity_template.h)
 
-            //find the number of arguments defined in the template (clarity_template.h)
+  size_t no_of_arguments =
+    to_code_type(functionExpression.type()).arguments().size();
 
-            size_t no_of_arguments = to_code_type(functionExpression.type()).arguments().size();
+  // since this is a test dummy. i am assuming just two fixed params to string_concat function
+  exprt arg1, arg2;
 
-            // since this is a test dummy. i am assuming just two fixed params to string_concat function
-            exprt arg1, arg2;
-           
+  // convert string literals to exprt nodes which are irept nodes.
+  convert_string_literal(literalA, arg1);
+  convert_string_literal(literalB, arg2);
 
-            // convert string literals to exprt nodes which are irept nodes.
-            convert_string_literal(literalA,arg1);
-            convert_string_literal(literalB,arg2);
+  call.arguments().push_back(arg1);
+  call.arguments().push_back(arg2);
 
-            call.arguments().push_back(arg1);
-            call.arguments().push_back(arg2);
+  // std::cout <<"Call node \n";
+  // std::cout <<call.pretty(4);
+  functionExpression = call;
 
-            // std::cout <<"Call node \n";
-            // std::cout <<call.pretty(4);
-            functionExpression = call;
+  // std::cout <<"Functionexpression node \n";
+  // std::cout <<functionExpression.pretty(4);
 
-            // std::cout <<"Functionexpression node \n";
-            // std::cout <<functionExpression.pretty(4);
-
-            clarity_gen_typecast(ns, functionExpression, symbolType);
-            addedSymbol.value = functionExpression;
-            if (addedSymbol.value.is_nil()) {
-              std::cout << "Added symbol value is nil\n";
-              } else {
-                  std::cout << "Added symbol value is assigned\n";
-              }
-            
-            
-
-          
+  clarity_gen_typecast(ns, functionExpression, symbolType);
+  addedSymbol.value = functionExpression;
+  if (addedSymbol.value.is_nil())
+  {
+    std::cout << "Added symbol value is nil\n";
+  }
+  else
+  {
+    std::cout << "Added symbol value is assigned\n";
+  }
 }
 void clarity_convertert::add_dummy_symbol()
 {
   bool experimental = true;
   if (experimental)
   {
-      //translate : define-constant myvar u23
-      //task : create a dummy symbol of 128 bits : unsigned
-      // add reference to that diagram which states all the members of a symbol
+//translate : define-constant myvar u23
+//task : create a dummy symbol of 128 bits : unsigned
+// add reference to that diagram which states all the members of a symbol
 
-      /*
+/*
         typet type;
         exprt value;
         locationt location;
@@ -848,235 +853,245 @@ void clarity_convertert::add_dummy_symbol()
         irep_idt mode;
       
       */
-      #define STRING_CONSTANT_ENABLED
-      #define UNSIGNED_INT_CONSTANT_ENABLED
-      //#define BUILTIN_FUNCTIONCALL_ENABLED
-      #define PUBLIC_FUNCTION_ENABLED
+#define STRING_CONSTANT_ENABLED
+#define UNSIGNED_INT_CONSTANT_ENABLED
+    //#define BUILTIN_FUNCTIONCALL_ENABLED
+    //#define PUBLIC_FUNCTION_ENABLED
 
-      #ifdef UNSIGNED_INT_CONSTANT_ENABLED
-        convert_dummy_uint_literal();
-      #endif
+#ifdef UNSIGNED_INT_CONSTANT_ENABLED
+    convert_dummy_uint_literal();
+#endif
 
-       #ifdef STRING_CONSTANT_ENABLED
-        convert_dummy_string_literal();
-      #endif
+#ifdef STRING_CONSTANT_ENABLED
+    convert_dummy_string_literal();
+#endif
 
-      #ifdef BUILTIN_FUNCTIONCALL_ENABLED
-        add_dummy_builtin_functionCall();
-      #endif
+#ifdef BUILTIN_FUNCTIONCALL_ENABLED
+    add_dummy_builtin_functionCall();
+#endif
 
-      #ifdef PUBLIC_FUNCTION_ENABLED
-      // add a code for adding a public function "add_nums"
-      // takes two arguments as input int x, and int y
-      // return an int
-      // (define-public (add_nums (num1 int) (num2 int)) (+ num1 num2))
-      // + is a binary operator. it should be handled as such.
-      // a binary operator in esbmc assumes an LHS and a RHS and an opcode.
+#ifdef PUBLIC_FUNCTION_ENABLED
+    // add a code for adding a public function "add_nums"
+    // takes two arguments as input int x, and int y
+    // return an int
+    // (define-public (add_nums (num1 int) (num2 int)) (+ num1 num2))
+    // + is a binary operator. it should be handled as such.
+    // a binary operator in esbmc assumes an LHS and a RHS and an opcode.
 
-      // steps :
-      // create symbol add_nums
-      std::string functionName = "add_nums";
-      std::string functionId = "clar:@C@basicDummy@F@" + functionName + "#123";
+    // steps :
+    // create symbol add_nums
+    std::string functionName = "add_nums";
+    std::string functionId = "clar:@C@basicDummy@F@" + functionName + "#123";
 
-      locationt locationBegin;
-      locationBegin.set_line("293");
-      locationBegin.set_file("basicDummy.clar");
+    locationt locationBegin;
+    locationBegin.set_line("293");
+    locationBegin.set_file("basicDummy.clar");
 
-      std::string debugModuleName = locationBegin.file().as_string();
+    std::string debugModuleName = locationBegin.file().as_string();
 
-      //function return type
-      code_typet symbolType;// = signedbv_typet(128);
-      symbolType.return_type() = signedbv_typet(128);
-      
-      symbolt symbol;
-      get_default_symbol(symbol,debugModuleName,symbolType,functionName,functionId,locationBegin);
+    //function return type
+    code_typet symbolType; // = signedbv_typet(128);
+    symbolType.return_type() = signedbv_typet(128);
 
+    symbolt symbol;
+    get_default_symbol(
+      symbol,
+      debugModuleName,
+      symbolType,
+      functionName,
+      functionId,
+      locationBegin);
 
-      symbol.lvalue = true;
-      symbol.file_local = false;
-      symbol.is_extern = false;
+    symbol.lvalue = true;
+    symbol.file_local = false;
+    symbol.is_extern = false;
 
-      symbolt &addedSymbol = *move_symbol_to_context(symbol);
+    symbolt &addedSymbol = *move_symbol_to_context(symbol);
 
-      //till now :  function name has been added to context 
+    //till now :  function name has been added to context
 
-      // get parameters list from AST
-      // for each param, do the following
-      // each param is a code_typet::argumentt type -> this is an exprt type
+    // get parameters list from AST
+    // for each param, do the following
+    // each param is a code_typet::argumentt type -> this is an exprt type
 
-      //argument 1
-      code_typet::argumentt param1;
-      param1.type() = signedbv_typet(128);
-      std::string param1_name = "num1";
-      param1.name(param1_name);
-      std::string param1_id = "clar:@C@basicDummy@F@" + functionName + "@" + param1_name + "#123";
-      //param1.id( param1_id);
-      param1.cmt_base_name(param1_name); 
-      
-      locationt param1_location;
-      param1_location.set_line("111");
-      param1_location.set_file("basicDummy.clar");
-      // we set cmt_identifier instead of type.id for arguments  
-      param1.cmt_identifier(param1_id);
-      param1.location() = param1_location;
+    //argument 1
+    code_typet::argumentt param1;
+    param1.type() = signedbv_typet(128);
+    std::string param1_name = "num1";
+    param1.name(param1_name);
+    std::string param1_id =
+      "clar:@C@basicDummy@F@" + functionName + "@" + param1_name + "#123";
+    //param1.id( param1_id);
+    param1.cmt_base_name(param1_name);
 
-      std::string debug_modulename =
+    locationt param1_location;
+    param1_location.set_line("111");
+    param1_location.set_file("basicDummy.clar");
+    // we set cmt_identifier instead of type.id for arguments
+    param1.cmt_identifier(param1_id);
+    param1.location() = param1_location;
+
+    std::string debug_modulename =
       get_modulename_from_path(param1_location.file().as_string());
 
-      symbolt param1_symbol;
-      get_default_symbol(param1_symbol,debug_modulename,param1.type(),param1_name,param1_id,param1_location);
-      param1_symbol.lvalue = true;
-      param1_symbol.is_parameter=true;
-      param1_symbol.file_local=true;
+    symbolt param1_symbol;
+    get_default_symbol(
+      param1_symbol,
+      debug_modulename,
+      param1.type(),
+      param1_name,
+      param1_id,
+      param1_location);
+    param1_symbol.lvalue = true;
+    param1_symbol.is_parameter = true;
+    param1_symbol.file_local = true;
 
-      symbolt &added_param1_symbol = *move_symbol_to_context(param1_symbol);
+    symbolt &added_param1_symbol = *move_symbol_to_context(param1_symbol);
 
-      //argument 2
-      code_typet::argumentt param2;
-      
-      param2.type() = signedbv_typet(128);
-      std::string param2_name = "num2";
-      param2.name(param2_name);
-      std::string param2_id = "clar:@C@basicDummy@F@" + functionName + "@" + param2_name + "#111";
-      param2.cmt_base_name(param2_name);
+    //argument 2
+    code_typet::argumentt param2;
 
-      locationt param2_location;
-      param2_location.set_line("111");
-      param2_location.set_file("basicDummy.clar");
-      param2.cmt_identifier(param2_id);
-      param2.location() = param2_location;
+    param2.type() = signedbv_typet(128);
+    std::string param2_name = "num2";
+    param2.name(param2_name);
+    std::string param2_id =
+      "clar:@C@basicDummy@F@" + functionName + "@" + param2_name + "#111";
+    param2.cmt_base_name(param2_name);
 
-      symbolt param2_symbol;
-      get_default_symbol(param2_symbol,debug_modulename,param2.type(),param2_name,param2_id,param2_location);
-      param2_symbol.lvalue = true;
-      param2_symbol.is_parameter=true;
-      param2_symbol.file_local=true;
+    locationt param2_location;
+    param2_location.set_line("111");
+    param2_location.set_file("basicDummy.clar");
+    param2.cmt_identifier(param2_id);
+    param2.location() = param2_location;
 
-      symbolt &added_param2_symbol = *move_symbol_to_context(param2_symbol);
+    symbolt param2_symbol;
+    get_default_symbol(
+      param2_symbol,
+      debug_modulename,
+      param2.type(),
+      param2_name,
+      param2_id,
+      param2_location);
+    param2_symbol.lvalue = true;
+    param2_symbol.is_parameter = true;
+    param2_symbol.file_local = true;
 
-      // add parameters to function type
+    symbolt &added_param2_symbol = *move_symbol_to_context(param2_symbol);
 
-      symbolType.arguments().push_back(param1);
-      symbolType.arguments().push_back(param2);
+    // add parameters to function type
 
-  
+    symbolType.arguments().push_back(param1);
+    symbolType.arguments().push_back(param2);
 
-      addedSymbol.type = symbolType;
+    addedSymbol.type = symbolType;
 
+    // create function body
+    // create a codet type exprt
 
-      
-      // create function body
-      // create a codet type exprt
+    //code_blockt functionBody = code_blockt();
+    // create a binary expression
+    //plus_exprt binExpr(symbol_exprt(param1_symbol),symbol_exprt(param2_symbol),signedbv_typet(128));
 
-      //code_blockt functionBody = code_blockt();
-      // create a binary expression
-      //plus_exprt binExpr(symbol_exprt(param1_symbol),symbol_exprt(param2_symbol),signedbv_typet(128));
+    exprt param1_expr = symbol_expr(added_param1_symbol);
+    exprt param2_expr = symbol_expr(added_param2_symbol);
 
-      exprt param1_expr = symbol_expr(added_param1_symbol);
-      exprt param2_expr = symbol_expr(added_param2_symbol);
-      
-      plus_exprt binExpr(param1_expr,param2_expr);
+    plus_exprt binExpr(param1_expr, param2_expr);
 
-      code_returnt returnStatement;
-      returnStatement.return_value() = binExpr;
-      irept param1_irept;
-      irept param2_irept;
-      added_param1_symbol.to_irep(param1_irept);
-      added_param2_symbol.to_irep(param2_irept);
-      // std::cout <<"Param 1 symbol : " << param1_irept.pretty(4) <<"\n";
-      // std::cout <<"Param 2 symbol : " << param2_irept.pretty(4) <<"\n";
-      // std::cout <<"Param 1 expr: " << param1_expr.pretty(4) <<"\n";
-      // std::cout <<"Param 2 expr: " << param2_expr.pretty(4) <<"\n";
-      // std::cout <<"Bin Expr : " << binExpr.pretty(4) <<"\n";
-      // std::cout <<"Return Statement : " <<returnStatement.pretty(4) <<"\n";
-      // std::cout <<"Function Body : " <<functionBody.pretty(4) <<"\n";
-    
-
+    code_returnt returnStatement;
+    returnStatement.return_value() = binExpr;
+    irept param1_irept;
+    irept param2_irept;
+    added_param1_symbol.to_irep(param1_irept);
+    added_param2_symbol.to_irep(param2_irept);
+    // std::cout <<"Param 1 symbol : " << param1_irept.pretty(4) <<"\n";
+    // std::cout <<"Param 2 symbol : " << param2_irept.pretty(4) <<"\n";
+    // std::cout <<"Param 1 expr: " << param1_expr.pretty(4) <<"\n";
+    // std::cout <<"Param 2 expr: " << param2_expr.pretty(4) <<"\n";
+    // std::cout <<"Bin Expr : " << binExpr.pretty(4) <<"\n";
+    // std::cout <<"Return Statement : " <<returnStatement.pretty(4) <<"\n";
+    // std::cout <<"Function Body : " <<functionBody.pretty(4) <<"\n";
 
     //functionBody.swap(returnStatement);
 
     // // refer to get_block function
     //   functionBody.operands().push_back(returnStmt);// .add(to_code_return(returnStmt));
 
-      // add function body to the symbol
-      addedSymbol.value = returnStatement;
-      #endif
-
-
-
+    // add function body to the symbol
+    addedSymbol.value = returnStatement;
+#endif
   }
-  else {
-
+  else
+  {
   }
 }
 
-bool clarity_convertert::check_valid_ast(const nlohmann::json & ast_node)
+bool clarity_convertert::check_valid_ast(const nlohmann::json &ast_node)
 {
-   if (!src_ast_json.contains(
-        "identifier")) // check json file contains expression AST nodes as Clarity might change
+  if (
+    !src_ast_json.contains(
+      "identifier")) // check json file contains expression AST nodes as Clarity might change
     assert(!"JSON file does not contain any expression AST nodes");
   return true;
 }
 bool clarity_convertert::convert()
 {
-
-  
-
   // This function consists of two parts:
   //  1. First, we perform pattern-based verificaiton (ToDo)
   //  2. Then we populate the context with symbols annotated based on the each AST node, and hence prepare for the GOTO conversion.
 
   check_valid_ast(src_ast_json);
 
-  absolute_path = current_fileName = contract_path; // this is set in the constructor
-
-  
+  absolute_path = current_fileName =
+    contract_path; // this is set in the constructor
 
   // By now the context should have the symbols of all ESBMC's intrinsics and the dummy main
   // We need to convert Clarity AST nodes to the equivalent symbols and add them to the context
   nlohmann::json &master_node = src_ast_json;
   nlohmann::json &nodes = src_ast_json; //src_ast_json["expressions"];
-  
 
   size_t index = 0;
-  
+
   bool found_contract_def = false;
 
   // find contract_identifier to verify if the ast is valid
 
-  if( master_node.contains("identifier") )
-  {  
+  if (master_node.contains("identifier"))
+  {
     //nodes = master_node["identifier"];
     std::string contract_name = master_node["identifier"]["contract_name"];
     set_current_contract_name(contract_name);
     std::string issuer = master_node["identifier"]["issuer_principal"];
-    
+
     //proper contract definition found
     found_contract_def = true;
-    
+
     current_contract_issuer = issuer;
 
-      // not sure what we'd use this for
-     if (get_clarity_struct_class(master_node))
-          return true;
-        
-         // add implicit construcor function
-        if (add_implicit_constructor())
-          return true;
+    // not sure what we'd use this for
+    if (get_clarity_struct_class(master_node))
+      return true;
 
-    log_status("Contract\t: {} \nIssuer\t: {}",current_contractName,current_contract_issuer);
- 
+    // add implicit construcor function
+    if (add_implicit_constructor())
+      return true;
+
+    log_status(
+      "Contract\t: {} \nIssuer\t: {}",
+      current_contractName,
+      current_contract_issuer);
   }
   else
   {
-    assert (!"AST JSON does not have contract name");
+    assert(!"AST JSON does not have contract name");
   }
 
   assert(found_contract_def && "No contracts were found in the program.");
-// Pattern based checking e-g Solidity checks for SWC-115
-  
-  log_status("Pattern based checking goes here . Solidity frontend had SWC-115 tested here.\nSkipping for Clarity for now. ");
-  #if 0
+  // Pattern based checking e-g Solidity checks for SWC-115
+
+  log_status(
+    "Pattern based checking goes here . Solidity frontend had SWC-115 tested "
+    "here.\nSkipping for Clarity for now. ");
+#if 0
   FIXME : (m-ali) we need to add pattern checking logic here e-g solidity checks for SVC 115
   for (nlohmann::json::iterator itr = nodes.begin(); itr != nodes.end();
        ++itr, ++index)
@@ -1102,47 +1117,45 @@ bool clarity_convertert::convert()
 
     
   }
-  #endif
+#endif
 
-  
-  // Exported symbols need to be checked here 
+  // Exported symbols need to be checked here
   //
   // FIXME :  (m-ali) @Faried bhai, does Clarity have exported Symbols.
   // we have exported symbols in "exported_functions" node in the AST
   log_status("What are exported symbols in Clarity ?\n ");
 
- 
   log_status("Exported symbols :");
   if (!src_ast_json["exported_functions"].is_array())
     assert(!"Exported functions is not an array");
-  
+
   for (const auto &itr : src_ast_json["exported_functions"])
   {
     //! Assume it has only one id
     std::string c_name = itr;
-    log_status("{}",c_name);
+    log_status("{}", c_name);
     //exportedSymbolsList.insert(std::pair<int, std::string>(c_id, c_name));
   }
 
   log_status("---------------------------");
-
- 
 
   // first round: handle definitions that can be outside of the contract
   // including struct, enum, interface, event, error, library...
   // noted that some can also be inside the contract, e.g. struct, enum...
   index = 0;
 
-  log_status("What are nonContract definitions , definitions outside of the contract in terms of clarity.\nSkipping for now.");
+  log_status(
+    "What are nonContract definitions , definitions outside of the contract in "
+    "terms of clarity.\nSkipping for now.");
   for (nlohmann::json::iterator itr = nodes.begin(); itr != nodes.end();
        ++itr, ++index)
   {
-    #if 0
+#if 0
     
     if (get_noncontract_defition(*itr))
       return true;
-    
-    #endif
+
+#endif
   }
 
   // second round: populate linearizedBaseList
@@ -1154,8 +1167,7 @@ bool clarity_convertert::convert()
   //FIXME : (m-ali) Do we need this for clarity ?
 
   //this is a dummy linearizedBaseList
-  linearizedBaseList[current_contractName].push_back(
-          9999);
+  linearizedBaseList[current_contractName].push_back(9999);
   assert(!linearizedBaseList[current_contractName].empty());
 
   // index = 0;
@@ -1177,37 +1189,34 @@ bool clarity_convertert::convert()
   //   }
   // }
 
-
   // third round: handle contract definition
   // single contract verification: where the option "--contract" is set.
   // multiple contracts verification: essentially verify the whole file.
   index = 0;
-  
 
-  for (nlohmann::json::iterator itr = src_ast_json.begin(); itr != src_ast_json.end();
+  for (nlohmann::json::iterator itr = src_ast_json.begin();
+       itr != src_ast_json.end();
        ++itr, ++index)
   {
-    log_status("Node type {}",itr->type_name());
+    log_status("Node type {}", itr->type_name());
 
     // we got to skip contract_identifier as we have already read that part.
     if (std::string(itr->type_name()) == "object")
     {
-     
-      std::cout <<"Key "<< itr.key()<<"\n";
+      std::cout << "Key " << itr.key() << "\n";
 
-      if (itr.key() == "indentifier" )
+      if (itr.key() == "indentifier")
       {
-       
         log_status("Skipping {} as we have already processed it", itr.key());
         continue;
-      } 
+      }
       else
         //log_status("Object not contract_identifier\n{}", itr->flatten());
-        std::cout <<"Object not contract_identifier\n"<< itr->flatten();
+        std::cout << "Object not contract_identifier\n" << itr->flatten();
     }
     else if (std::string(itr->type_name()) == "array")
     {
-      std::cout <<"Key "<<itr.key()<<"\n";
+      std::cout << "Key " << itr.key() << "\n";
 
       /* Expressions Array is an array of Arrays.
         Each array element is an array. Each nested array is a mixed element array 
@@ -1215,48 +1224,51 @@ bool clarity_convertert::convert()
 
       if (itr.key() == "expressions")
       {
-        auto vec_expressions = itr.value();  
+        auto vec_expressions = itr.value();
         // handle expressions here.
         log_status("Found expressions array ...");
-        std::cout <<"Number of expressions in contract " <<current_contractName <<"  : " << vec_expressions.size()<<"\n";
-        
+        std::cout << "Number of expressions in contract "
+                  << current_contractName << "  : " << vec_expressions.size()
+                  << "\n";
+
         //process expression array
         for (auto &expr : vec_expressions)
         {
-          log_status("Parsing {} {} ",expr[0].get<std::string>(), expr[1]["identifier"].get<std::string>());
+          log_status(
+            "Parsing {} {} ",
+            expr[0].get<std::string>(),
+            expr[1]["identifier"].get<std::string>());
+
+          add_dummy_symbol();
           if (ClarityGrammar::parse_expression_element(expr))
           {
             log_error("Invalid expression element");
             continue;
           }
-           // for each element in expressions array
-           // check if valid expression array
-         
-           if (convert_ast_nodes(expr))
-              return true;
+          // for each element in expressions array
+          // check if valid expression array
+
+          if (convert_ast_nodes(expr))
+            return true;
         }
-
-
-
       }
       else if (itr.key() == "exported_functions")
       {
-        std::cout <<" Exported functions not handled yet"<<"\n";
+        std::cout << " Exported functions not handled yet"
+                  << "\n";
         continue;
       }
     }
     else
     {
-      std::cout <<"Key "<< itr.key()<<"\n";
+      std::cout << "Key " << itr.key() << "\n";
       log_status("Unsupported type ...");
       continue;
     }
 
-
-
     // reset
-    current_contractName = "";
-    current_functionName = "";
+    //current_contractName = "";
+    //current_functionName = "";
     current_functionDecl = nullptr;
     current_forStmt = nullptr;
     global_scope_id = 0;
@@ -1284,21 +1296,22 @@ bool clarity_convertert::convert()
 bool clarity_convertert::convert_ast_nodes(const nlohmann::json &contract_def)
 {
   size_t index = 0;
-  
-    nlohmann::json ast_node = contract_def;
-    std::string identifier_name = ast_node[1]["identifier"].get<std::string>();
-    std::string identifier_type = get_objtype_type_name(ast_node[1]["objtype"]);    //std::string(ast_node[1]["objtype"][0]; //.type_name());
-    log_debug(
-      "clarity",
-      "@@ Converting node[{}]: name={}, nodeType={} ...",
-      index,
-      identifier_name.c_str(),
-      identifier_type.c_str());
-    exprt dummy_decl;
-    if (get_decl(ast_node, dummy_decl))
-      return true;
- 
-  
+
+  nlohmann::json ast_node = contract_def;
+  std::string identifier_name = ast_node[1]["identifier"].get<std::string>();
+  std::string identifier_type = get_objtype_type_name(
+    ast_node
+      [1]["objtype"]); //std::string(ast_node[1]["objtype"][0]; //.type_name());
+  log_debug(
+    "clarity",
+    "@@ Converting node[{}]: name={}, nodeType={} ...",
+    index,
+    identifier_name.c_str(),
+    identifier_type.c_str());
+  exprt dummy_decl;
+  if (get_decl(ast_node, dummy_decl))
+    return true;
+
   // After converting all AST nodes, current_functionDecl should be restored to nullptr.
   assert(current_functionDecl == nullptr);
 
@@ -1389,8 +1402,7 @@ bool clarity_convertert::get_var_decl(
   // For array, do NOT use ["typeName"]. Otherwise, it will cause problem
   // when populating typet in get_cast
 
-  
-  bool mapping = false ; //is_child_mapping(ast_node);
+  bool mapping = false; //is_child_mapping(ast_node);
   if (mapping)
   {
     // the mapping should not handled in var decl, instead
@@ -1444,7 +1456,6 @@ bool clarity_convertert::get_var_decl(
   // 2. populate id and name
   std::string name, id;
 
-
   if (is_state_var)
     get_state_var_decl_name(ast_node, name, id);
   else if (current_functionDecl)
@@ -1470,19 +1481,27 @@ bool clarity_convertert::get_var_decl(
   symbolt symbol;
   get_default_symbol(symbol, debug_modulename, t, name, id, location_begin);
 
-  symbol.lvalue = true;
-  symbol.static_lifetime = is_state_var;
-  symbol.file_local = !is_state_var;
-  symbol.is_extern = false;
+  if (ClarityGrammar::is_tuple_declaration(ast_node))
+    symbol.is_type = true;
+  else
+  {
+    symbol.lvalue = true;
+    symbol.static_lifetime = is_state_var;
+    symbol.file_local = !is_state_var;
+    symbol.is_extern = false;
+  }
 
   // initialise with zeroes if no initial value provided.
-  bool has_init = ast_node[1].contains("value") ;  // in clarity we do not use "initialValue"
+  bool has_init =
+    ast_node[1].contains("value"); // in clarity we do not use "initialValue"
   if (symbol.static_lifetime && !symbol.is_extern && !has_init)
   {
     // set default value as zero
     symbol.value = gen_zero(t, true);
     symbol.value.zero_initializer(true);
   }
+
+  // FIXME : add exception for if we don't have value node
 
   // 6. add symbol into the context
   // just like clang-c-frontend, we have to add the symbol before converting the initial assignment
@@ -1493,10 +1512,13 @@ bool clarity_convertert::get_var_decl(
 
   if (has_init)
   {
-    nlohmann::json init_value =  ast_node[1]["value"];  //refer to AST parsing rules : "Rules for reading Value Node"
-    
+    nlohmann::json init_value = ast_node
+      [1]
+      ["value"]; //refer to AST parsing rules : "Rules for reading Value Node"
+
     //this might cause issue
-    nlohmann::json literal_type = get_objtype_type_name(ast_node[1]["objtype"]) ;//ast_node[1]["objtype"][1];
+    nlohmann::json literal_type = get_objtype_type_name(
+      ast_node[1]["objtype"]); //ast_node[1]["objtype"][1];
 
     assert(literal_type != nullptr);
     exprt val;
@@ -1556,16 +1578,16 @@ bool clarity_convertert::get_var_decl(
 
 // This function handles both contract and struct
 // The contract can be regarded as the class in C++, converting to a struct
-bool clarity_convertert::get_clarity_struct_class(const nlohmann::json &struct_def)
+bool clarity_convertert::get_clarity_struct_class(
+  const nlohmann::json &struct_def)
 {
   // 1. populate name, id
   std::string id, name;
   struct_typet t = struct_typet();
 
-  name = get_current_contract_name(struct_def, name);
+  get_current_contract_name(struct_def, name);
   id = prefix + name;
   t.tag(name);
-
 
   // 2. Check if the symbol is already added to the context, do nothing if it is
   // already in the context.
@@ -1574,7 +1596,7 @@ bool clarity_convertert::get_clarity_struct_class(const nlohmann::json &struct_d
 
   // 3. populate location
   locationt location_begin;
-  
+
   location_begin.set_line(0);
   location_begin.set_file(absolute_path);
 
@@ -1614,7 +1636,7 @@ bool clarity_convertert::get_clarity_struct_class(const nlohmann::json &struct_d
   //   log_warning("Empty contract.");
   // }
 
-  // m-ali : todo . we probably don't need this 
+  // m-ali : todo . we probably don't need this
 
   // for (nlohmann::json::iterator itr = ast_nodes.begin(); itr != ast_nodes.end();
   //      ++itr)
@@ -1663,7 +1685,6 @@ bool clarity_convertert::get_struct_class(const nlohmann::json &struct_def)
   id = prefix + name;
   t.tag(name);
 
-
   // 2. Check if the symbol is already added to the context, do nothing if it is
   // already in the context.
   if (context.find_symbol(id) != nullptr)
@@ -1672,7 +1693,7 @@ bool clarity_convertert::get_struct_class(const nlohmann::json &struct_def)
   // 3. populate location
   locationt location_begin;
   get_location_from_decl(struct_def, location_begin);
-  
+
   // 4. populate debug module name
   std::string debug_modulename =
     get_modulename_from_path(location_begin.file().as_string());
@@ -1694,8 +1715,6 @@ bool clarity_convertert::get_struct_class(const nlohmann::json &struct_def)
   // We have to add fields before methods as the fields are likely to be used
   // in the methods
 
-  
-
   nlohmann::json ast_nodes;
   if (struct_def.contains("nodes"))
     ast_nodes = struct_def["nodes"];
@@ -1707,8 +1726,6 @@ bool clarity_convertert::get_struct_class(const nlohmann::json &struct_def)
     // Contracts can be empty
     log_warning("Empty contract.");
   }
-
-  
 
   for (nlohmann::json::iterator itr = ast_nodes.begin(); itr != ast_nodes.end();
        ++itr)
@@ -2083,15 +2100,15 @@ bool clarity_convertert::get_function_definition(const nlohmann::json &ast_node)
   return false;
 }
 
-
 void clarity_convertert::NewFunction(code_typet &type)
 {
-if (type.arguments().empty())
+  if (type.arguments().empty())
   {
     // assume ellipsis if the function has no parameters
     type.make_ellipsis();
   }
-}bool clarity_convertert::get_function_params(
+}
+bool clarity_convertert::get_function_params(
   const nlohmann::json &pd,
   exprt &param)
 {
@@ -2629,9 +2646,9 @@ bool clarity_convertert::get_expr(const nlohmann::json &expr, exprt &new_expr)
      * @return false iff the conversion was successful
      */
 
-  // FIX ABOVE COMMENTS
-  //  literal_type is objtype
-  // expr is the whole expression node
+// FIX ABOVE COMMENTS
+//  literal_type is objtype
+// expr is the whole expression node
 bool clarity_convertert::get_expr(
   const nlohmann::json &expr,
   const nlohmann::json &literal_type,
@@ -2758,7 +2775,7 @@ bool clarity_convertert::get_expr(
       ClarityGrammar::get_elementary_type_name_t(literal);
     std::string the_value;
 
-    if (type_name == ClarityGrammar::ElementaryTypeNameT::STRING_ASCII )
+    if (type_name == ClarityGrammar::ElementaryTypeNameT::STRING_ASCII)
     {
       // for string literal
       the_value = expr[1]["value"]["lit_ascii"].get<std::string>();
@@ -2772,46 +2789,62 @@ bool clarity_convertert::get_expr(
     {
       the_value = expr[1]["value"].get<std::string>();
     }
-    
-    
-    
-    
+
     log_debug(
       "clarity",
       "	@@@ got Literal: ClarityGrammar::ElementaryTypeNameT::{}",
       ClarityGrammar::elementary_type_name_to_str(type_name));
 
-    if (
-      literal_type != nullptr ) 
+    if (literal_type != nullptr)
     {
-      // literal_type["typeString"] could be
-      //    "bytes1" ... "bytes32"
-      //    "bytes storage ref"
-      // e.g.
-      //    bytes1 x = 0x12;
-      //    bytes32 x = "string";
-      //    bytes x = "string";
-      //
-
       ClarityGrammar::ElementaryTypeNameT type = type_name;
-    
 
-      // convert hex to decimal value and populate
       switch (type_name)
       {
-
       case ClarityGrammar::ElementaryTypeNameT::BUFF:
       {
-         if (
-        the_value.length() >= 2 &&
-        the_value.substr(0, 2) == "0x") // meaning hex-string
+        if (
+          the_value.length() >= 2 &&
+          the_value.substr(0, 2) == "0x") // meaning hex-string
         {
+          the_value.erase(0, 2); //remove the first two characters (0x)
+
           std::string str_buff_size = literal_type[2];
           int buff_size = std::stoi(str_buff_size);
-          if (convert_hex_literal(the_value, new_expr, buff_size * 8))
-            return true;
+
+          // Buffer is sort of an array of bytes
+          typet type = array_typet(
+            unsigned_char_type(), from_integer(buff_size, size_type()));
+          exprt buff_inits = gen_zero(type);
+
+          // the string value should be 2xbuff_size long
+          // one byte = 2 characters
+
+          int i = 0;
+          int value_length = the_value.length();
+          for (i = 0; i < value_length / 2; i++)
+          {
+            unsigned int buff_elem =
+              std::stoi(the_value.substr(i * 2, 2), nullptr, 16);
+            exprt val = constant_exprt(buff_elem, unsigned_char_type());
+            buff_inits.operands().at(i) = val;
+          }
+
+          // Handle the case where the last byte is not a complete byte
+          if (the_value.length() % 2 != 0)
+          {
+            std::string last_byte_str =
+              the_value.substr(the_value.length() - 1, 1);
+            unsigned int last_byte = std::stoi(last_byte_str, nullptr, 16);
+            exprt last_byte_expr =
+              constant_exprt(last_byte, unsigned_char_type());
+            buff_inits.operands().at(i) = last_byte_expr;
+          }
+
+          new_expr.swap(buff_inits);
         }
-        else{
+        else
+        {
           log_error("Invalid buff value found. Missing 0x prefix");
           return true;
         }
@@ -2820,7 +2853,6 @@ bool clarity_convertert::get_expr(
       case ClarityGrammar::ElementaryTypeNameT::UINT:
       case ClarityGrammar::ElementaryTypeNameT::UINT_LITERAL:
       {
-        
         if (convert_uint_literal(literal, the_value, new_expr))
           return true;
         break;
@@ -2828,7 +2860,6 @@ bool clarity_convertert::get_expr(
       case ClarityGrammar::ElementaryTypeNameT::INT:
       case ClarityGrammar::ElementaryTypeNameT::INT_LITERAL:
       {
-        
         if (convert_integer_literal(literal, the_value, new_expr))
           return true;
         break;
@@ -2847,7 +2878,7 @@ bool clarity_convertert::get_expr(
           return true;
         break;
       }
-      
+
       case ClarityGrammar::ElementaryTypeNameT::STRING_UTF8:
       case ClarityGrammar::ElementaryTypeNameT::STRING_UTF8_LITERAL:
       {
@@ -2855,14 +2886,14 @@ bool clarity_convertert::get_expr(
           return true;
         break;
       }
-      case ClarityGrammar::ElementaryTypeNameT::ADDRESS:
+      case ClarityGrammar::ElementaryTypeNameT::PRINCIPAL:
       {
         // 20 bytes
         if (convert_hex_literal(the_value, new_expr, 160))
           return true;
         break;
       }
-      
+
       // case ClarityGrammar::ElementaryTypeNameT::STRING_UTF8_LITERAL:
       // {
       //   // TODO: this is likely incorrect as well
@@ -2884,154 +2915,161 @@ bool clarity_convertert::get_expr(
       break;
     }
 
-    
     break;
   }
   case ClarityGrammar::ExpressionT::Tuple:
   {
-    // "nodeType": "TupleExpression":
-    //    1. InitList: uint[3] x = [1, 2, 3];
-    //    2. Operator:
-    //        - (x+1) % 2
-    //        - if( x && (y || z) )
-    //    3. TupleExpr:
-    //        - multiple returns: return (x, y);
-    //        - (x, y) = (y, x)
+    /*
+      for each "component" in "objtype[1]"
+      1. get the type of the component
+      2. get the value of the component
+      3. create a new exprt for the component
+      4. add the component to the tuple
+      5. return the tuple
+    
+    */
 
-    assert(expr.contains("components"));
-    ClarityGrammar::TypeNameT type =
-      ClarityGrammar::get_type_name_t(expr["typeDescriptions"]);
+    // 1. construct struct type
+    if (get_tuple_definition(expr))
+      return true;
 
-    switch (type)
-    {
-    // case 1
-    case ClarityGrammar::TypeNameT::ArrayTypeName:
-    {
-      assert(literal_type != nullptr);
+    //2. construct struct_type instance
+    if (get_tuple_instance(expr, new_expr))
+      return true;
 
-      // get elem type
-      nlohmann::json elem_literal_type =
-        make_array_elementary_type(literal_type);
+    // older code : has useful comments to read
+    // assert(expr.contains("components"));
 
-      // get size
-      exprt size;
-      size = constant_exprt(
-        integer2binary(expr["components"].size(), bv_width(int_type())),
-        integer2string(expr["components"].size()),
-        int_type());
+    // switch (type)
+    // {
+    // // case 1
+    // case ClarityGrammar::TypeNameT::ArrayTypeName:
+    // {
+    //   assert(literal_type != nullptr);
 
-      // get array type
-      typet arr_type;
-      if (get_type_description(literal_type, arr_type))
-        return true;
+    //   // get elem type
+    //   nlohmann::json elem_literal_type =
+    //     make_array_elementary_type(literal_type);
 
-      // reallocate array size
-      arr_type = array_typet(arr_type.subtype(), size);
+    //   // get size
+    //   exprt size;
+    //   size = constant_exprt(
+    //     integer2binary(expr["components"].size(), bv_width(int_type())),
+    //     integer2string(expr["components"].size()),
+    //     int_type());
 
-      // declare static array tuple
-      exprt inits;
-      inits = gen_zero(arr_type);
+    //   // get array type
+    //   typet arr_type;
+    //   if (get_type_description(literal_type, arr_type))
+    //     return true;
 
-      // populate array
-      int i = 0;
-      for (const auto &arg : expr["components"].items())
-      {
-        exprt init;
-        if (get_expr(arg.value(), elem_literal_type, init))
-          return true;
+    //   // reallocate array size
+    //   arr_type = array_typet(arr_type.subtype(), size);
 
-        inits.operands().at(i) = init;
-        i++;
-      }
+    //   // declare static array tuple
+    //   exprt inits;
+    //   inits = gen_zero(arr_type);
 
-      new_expr = inits;
-      break;
-    }
+    //   // populate array
+    //   int i = 0;
+    //   for (const auto &arg : expr["components"].items())
+    //   {
+    //     exprt init;
+    //     if (get_expr(arg.value(), elem_literal_type, init))
+    //       return true;
 
-    // case 3
-    case ClarityGrammar::TypeNameT::TupleTypeName: // case 3
-    {
-      /*
-      we assume there are three types of tuple expr:
-      0. dump: (x,y);
-      1. fixed: (x,y) = (y,x);
-      2. function-related:
-          2.1. (x,y) = func();
-          2.2. return (x,y);
+    //     inits.operands().at(i) = init;
+    //     i++;
+    //   }
 
-      case 0:
-        1. create a struct type
-        2. create a struct type instance
-        3. new_expr = instance
-        e.g.
-        (x , y) ==>
-        struct Tuple
-        {
-          uint x,
-          uint y
-        };
-        Tuple tuple;
+    //   new_expr = inits;
+    //   break;
+    // }
 
-      case 1:
-        1. add special handling in binary operation.
-           when matching struct_expr A = struct_expr B,
-           divided into A.operands()[i] = B.operands()[i]
-           and populated into a code_block.
-        2. new_expr = code_block
-        e.g.
-        (x, y) = (1, 2) ==>
-        {
-          tuple.x = 1;
-          tuple.y = 2;
-        }
-        ? any potential scope issue?
+    // // case 3
+    // case ClarityGrammar::TypeNameT::TupleTypeName: // case 3
+    // {
+    //   /*
+    //   we assume there are three types of tuple expr:
+    //   0. dump: (x,y);
+    //   1. fixed: (x,y) = (y,x);
+    //   2. function-related:
+    //       2.1. (x,y) = func();
+    //       2.2. return (x,y);
 
-      case 2:
-        1. when parsing the funciton definition, if the returnParam > 1
-           make the function return void instead, and create a struct type
-        2. when parsing the return statement, if the return value is a tuple,
-           create a struct type instance, do assignments,  and return empty;
-        3. when the lhs is tuple and rhs is func_call, get_tuple_instance_expr based
-           on the func_call, and do case 1.
-        e.g.
-        function test() returns (uint, uint)
-        {
-          return (1,2);
-        }
-        ==>
-        struct Tuple
-        {
-          uint x;
-          uint y;
-        }
-        function test()
-        {
-          Tuple tuple;
-          tuple.x = 1;
-          tuple.y = 2;
-          return;
-        }
-      */
+    //   case 0:
+    //     1. create a struct type
+    //     2. create a struct type instance
+    //     3. new_expr = instance
+    //     e.g.
+    //     (x , y) ==>
+    //     struct Tuple
+    //     {
+    //       uint x,
+    //       uint y
+    //     };
+    //     Tuple tuple;
 
-      // 1. construct struct type
-      if (get_tuple_definition(expr))
-        return true;
+    //   case 1:
+    //     1. add special handling in binary operation.
+    //        when matching struct_expr A = struct_expr B,
+    //        divided into A.operands()[i] = B.operands()[i]
+    //        and populated into a code_block.
+    //     2. new_expr = code_block
+    //     e.g.
+    //     (x, y) = (1, 2) ==>
+    //     {
+    //       tuple.x = 1;
+    //       tuple.y = 2;
+    //     }
+    //     ? any potential scope issue?
 
-      //2. construct struct_type instance
-      if (get_tuple_instance(expr, new_expr))
-        return true;
+    //   case 2:
+    //     1. when parsing the funciton definition, if the returnParam > 1
+    //        make the function return void instead, and create a struct type
+    //     2. when parsing the return statement, if the return value is a tuple,
+    //        create a struct type instance, do assignments,  and return empty;
+    //     3. when the lhs is tuple and rhs is func_call, get_tuple_instance_expr based
+    //        on the func_call, and do case 1.
+    //     e.g.
+    //     function test() returns (uint, uint)
+    //     {
+    //       return (1,2);
+    //     }
+    //     ==>
+    //     struct Tuple
+    //     {
+    //       uint x;
+    //       uint y;
+    //     }
+    //     function test()
+    //     {
+    //       Tuple tuple;
+    //       tuple.x = 1;
+    //       tuple.y = 2;
+    //       return;
+    //     }
+    //   */
 
-      break;
-    }
+    //   // 1. construct struct type
+    //   if (get_tuple_definition(expr))
+    //     return true;
 
-    // case 2
-    default:
-    {
-      if (get_expr(expr["components"][0], literal_type, new_expr))
-        return true;
-      break;
-    }
-    }
+    //   //2. construct struct_type instance
+    //   if (get_tuple_instance(expr, new_expr))
+    //     return true;
+
+    //   break;
+    // }
+
+    // // case 2
+    // default:
+    // {
+    //   if (get_expr(expr["components"][0], literal_type, new_expr))
+    //     return true;
+    //   break;
+    // }
+    // }
 
     break;
   }
@@ -3285,7 +3323,7 @@ bool clarity_convertert::get_expr(
         expr["baseExpression"]["typeDescriptions"]);
       if (
         !(tname == ClarityGrammar::ArrayTypeName) &&
-         
+
         expr["baseExpression"].contains("referencedDeclaration"))
       {
         // e.g.
@@ -3553,19 +3591,15 @@ bool clarity_convertert::get_expr(
   return false;
 }
 
-void clarity_convertert::set_current_contract_name(
-  std::string &contract_name)
+void clarity_convertert::set_current_contract_name(std::string &contract_name)
 {
-
   current_contractName = contract_name;
-  
 }
 
 bool clarity_convertert::get_current_contract_name(
   const nlohmann::json &ast_node,
   std::string &contract_name)
 {
-
   contract_name = current_contractName;
   return false;
 
@@ -4492,27 +4526,25 @@ bool clarity_convertert::get_type_description(
   }
   case ClarityGrammar::TypeNameT::BuffTypeName:
   {
-        //it's a buffer of bytes
-        // std::string str_buff_size = type_name[2];
-        // int bit_width = 8 * std::stoi(str_buff_size);
-        // new_type = unsignedbv_typet(bit_width);
-        
-        if (get_elementary_type_name_bytesn(type_name, new_type))
-          return true;
+    //it's a buffer of bytes
+    // std::string str_buff_size = type_name[2];
+    // int bit_width = 8 * std::stoi(str_buff_size);
+    // new_type = unsignedbv_typet(bit_width);
 
-   
-   break;
+    if (get_elementary_type_name_buff(type_name, new_type))
+      return true;
+
+    break;
   }
   case ClarityGrammar::TypeNameT::ArrayTypeName:
   {
     // Deal with array with constant size, e.g., int a[2]; Similar to clang::Type::ConstantArray
     // buff is an array of bytes
     // list is an array of entry-type
-   
-  
-      //it's a list of entry-type
-      // ToDo
-      nlohmann::json array_elementary_type =
+
+    //it's a list of entry-type
+    // ToDo
+    nlohmann::json array_elementary_type =
       make_array_elementary_type(type_name);
     typet the_type;
     if (get_type_description(array_elementary_type, the_type))
@@ -4527,15 +4559,14 @@ bool clarity_convertert::get_type_description(
         integer2binary(z_ext_value, bv_width(int_type())),
         integer2string(z_ext_value),
         int_type()));
-   
-   
-    
 
     break;
   }
 
   case ClarityGrammar::TypeNameT::ContractTypeName:
   {
+    // ToDo
+    // FIXME
     // e.g. ContractName tmp = new ContractName(Args);
 
     std::string constructor_name = type_name["typeString"].get<std::string>();
@@ -4604,7 +4635,6 @@ bool clarity_convertert::get_type_description(
   }
   case ClarityGrammar::TypeNameT::TupleTypeName:
   {
-    // do nothing as it won't be used
     new_type = struct_typet();
     new_type.set("#cpp_type", "void");
     new_type.set("#clar_type", "tuple");
@@ -4767,34 +4797,29 @@ bool clarity_convertert::get_tuple_definition(const nlohmann::json &ast_node)
   get_default_symbol(symbol, debug_modulename, t, name, id, location_begin);
   symbolt &added_symbol = *move_symbol_to_context(symbol);
 
-  auto &args = ast_node.contains("components")
-                 ? ast_node["components"]
-                 : ast_node["returnParameters"]["parameters"];
-
   // populate params
   //TODO: flatten the nested tuple (e.g. ((x,y),z) = (func(),1); )
   size_t counter = 0;
-  for (const auto &arg : args.items())
-  {
-    if (arg.value().is_null())
-    {
-      ++counter;
-      continue;
-    }
+  nlohmann::json objtype = ast_node[1]["objtype"][1];
+  //std::cout <<objtype.dump(4)<<std::endl;
 
+  //  //for loop to iterate over all keys of objtype
+  for (nlohmann::json::iterator it = objtype.begin(); it != objtype.end(); ++it)
+  {
     struct_typet::componentt comp;
 
     // manually create a member_name
     // follow the naming rule defined in get_var_decl_name
     assert(!current_contractName.empty());
-    const std::string mem_name = "mem" + std::to_string(counter);
+    //const std::string mem_name = "mem" + std::to_string(counter);
+    const std::string mem_name = it.key();
     const std::string mem_id = "clar:@C@" + current_contractName + "@" + name +
                                "@" + mem_name + "#" +
-                               i2string(ast_node["id"].get<std::int16_t>());
+                               i2string(ast_node[1]["cid"].get<std::int16_t>());
 
     // get type
     typet mem_type;
-    if (get_type_description(arg.value()["typeDescriptions"], mem_type))
+    if (get_type_description(it.value(), mem_type))
       return true;
 
     // construct comp
@@ -4804,7 +4829,7 @@ bool clarity_convertert::get_tuple_definition(const nlohmann::json &ast_node)
     comp.cmt_lvalue(true);
     comp.name(mem_name);
     comp.pretty_name(mem_name);
-    comp.set_access("internal");
+    //comp.set_access("internal");
 
     // update struct type component
     t.components().push_back(comp);
@@ -4851,48 +4876,69 @@ bool clarity_convertert::get_tuple_instance(
   // populate struct type symbol
   symbolt symbol;
   get_default_symbol(symbol, debug_modulename, t, name, id, location_begin);
+
+  symbol.lvalue = true;
+  symbol.static_lifetime = true;
+  symbol.file_local = false;
+  symbol.is_extern = false;
   symbolt &added_symbol = *move_symbol_to_context(symbol);
 
-  if (!ast_node.contains("components"))
-  {
-    // assume it's function return parameter list
-    // therefore no initial value
-    new_expr = symbol_expr(added_symbol);
+  // not needed for clarity
+  // keeping for reference purpose only
+  // FIXME
 
-    return false;
-  }
+  // if (!ast_node.contains("components"))
+  // {
+  //   // assume it's function return parameter list
+  //   // therefore no initial value
+  //   new_expr = symbol_expr(added_symbol);
+
+  //   return false;
+  // }
 
   // populate initial value
-  // e.g. (1,2) ==> Tuple tuple = Tuple(1,2);
-  //! since there is no tuple type variable in clarity
-  // we can just convert it as inital value instead of assignment
-  //? should we set the default value as zero?
 
   exprt inits = gen_zero(t);
-  auto &args = ast_node["components"];
+  nlohmann::json objtype = ast_node[1]["objtype"];
 
   size_t i = 0;
-  size_t j = 0;
-  unsigned is = inits.operands().size();
-  unsigned as = args.size();
+  int is = inits.operands().size();
+  int as = objtype[2].get<int>();
   assert(is <= as);
 
-  while (i < is && j < as)
+  for (nlohmann::json::iterator it = objtype[1].begin(); it != objtype[1].end();
+       ++it)
   {
-    if (args.at(j).is_null())
-    {
-      ++j;
-      continue;
-    }
+    //get the type of the component
+    nlohmann::json component_type = it.value();
+    std::string tuple_key = it.key();
+    ClarityGrammar::TypeNameT type =
+      ClarityGrammar::get_type_name_t(component_type);
 
+    //Fixme: right now it only handles elementary types
+    // we will need to pass it the whole get_expr function to handle more complex types.
+    // recursive call to get_expr
+    ClarityGrammar::ElementaryTypeNameT type_name =
+      ClarityGrammar::get_elementary_type_name_t(component_type);
+
+    /* Create a temporary JSON object to ease processing */
+    nlohmann::json temp_expression_node;
+    temp_expression_node["expressionType"] = "Literal";
+    temp_expression_node["span"] = ast_node[1]["span"];
+    temp_expression_node["identifier"] = tuple_key;
+    temp_expression_node["cid"] = ast_node[1]["cid"];
+    temp_expression_node["objtype"] = component_type;
+    temp_expression_node["value"] = ast_node[1]["value"][1][tuple_key];
+
+    nlohmann::json temp_declarative_node = {"tuple", temp_expression_node};
+
+    //std::string the_value = expr[1][tuple_key].get<std::string>();
+    std::cout << temp_declarative_node.dump(4) << std::endl;
     exprt init;
-    const nlohmann::json &litera_type = args.at(j)["typeDescriptions"];
-
-    if (get_expr(args.at(j), litera_type, init))
+    if (get_expr(temp_declarative_node, component_type, init))
       return true;
 
-    const struct_union_typet::componentt *c =
-      &to_struct_type(t).components().at(i);
+    const struct_typet::componentt *c = &to_struct_type(t).components().at(i);
     typet elem_type = c->type();
 
     clarity_gen_typecast(ns, init, elem_type);
@@ -4900,7 +4946,6 @@ bool clarity_convertert::get_tuple_instance(
 
     // update
     ++i;
-    ++j;
   }
 
   added_symbol.value = inits;
@@ -4914,7 +4959,11 @@ void clarity_convertert::get_tuple_name(
   std::string &name,
   std::string &id)
 {
-  name = "tuple" + std::to_string(ast_node["id"].get<int>());
+  name =
+    "tuple_" +
+    ast_node[1]["identifier"]
+      .get<
+        std::string>(); //+ "#" + std::to_string(ast_node[1]["cid"].get<int>());
   id = prefix + "struct " + name;
 }
 
@@ -4929,7 +4978,11 @@ bool clarity_convertert::get_tuple_instance_name(
   if (c_name.empty())
     return true;
 
-  name = "tuple_instance" + std::to_string(ast_node["id"].get<int>());
+  //name = "tuple_instance_" + ast_node[1]["identifier"].get<std::string>(); //+ "#"+ std::to_string(ast_node[1]["cid"].get<int>());
+  name =
+    ast_node[1]["identifier"]
+      .get<
+        std::string>(); //+ "#"+ std::to_string(ast_node[1]["cid"].get<int>());
   id = "clar:@C@" + c_name + "@" + name;
   return false;
 }
@@ -5036,6 +5089,22 @@ bool clarity_convertert::get_elementary_type_name_int(
   return false;
 }
 
+bool clarity_convertert::get_elementary_type_name_buff(
+  const nlohmann::json &objtype,
+  typet &out)
+{
+  /*
+    bytes1 has size of 8 bits (possible values 0x00 to 0xff),
+    which you can implicitly convert to uint8 (unsigned integer of size 8 bits) but not to int8
+  */
+
+  std::string str_buff_size = objtype[2];
+  const unsigned int bytes = std::stoi(str_buff_size);
+  out = array_typet(unsigned_char_type(), from_integer(bytes, size_type()));
+
+  return false;
+}
+
 bool clarity_convertert::get_elementary_type_name_bytesn(
   const nlohmann::json &objtype,
   typet &out)
@@ -5044,7 +5113,7 @@ bool clarity_convertert::get_elementary_type_name_bytesn(
     bytes1 has size of 8 bits (possible values 0x00 to 0xff),
     which you can implicitly convert to uint8 (unsigned integer of size 8 bits) but not to int8
   */
-  
+
   std::string str_buff_size = objtype[2];
   const unsigned int bytes = std::stoi(str_buff_size);
   out = unsignedbv_typet(bytes * 8);
@@ -5085,7 +5154,7 @@ bool clarity_convertert::get_elementary_type_name(
       return true;
     break;
   }
-  
+
   case ClarityGrammar::ElementaryTypeNameT::BOOL:
   {
     new_type = bool_type();
@@ -5096,7 +5165,7 @@ bool clarity_convertert::get_elementary_type_name(
   case ClarityGrammar::ElementaryTypeNameT::STRING_ASCII:
   {
     // obj[2] contains size of object
-    std::string str_value_length =  objtype[2];
+    std::string str_value_length = objtype[2];
     size_t value_length = std::stoi(str_value_length);
 
     new_type = array_typet(
@@ -5110,7 +5179,7 @@ bool clarity_convertert::get_elementary_type_name(
   case ClarityGrammar::ElementaryTypeNameT::STRING_UTF8:
   {
     // TODO: and this
-    std::string str_value_length =  objtype[2];
+    std::string str_value_length = objtype[2];
     size_t value_length = std::stoi(str_value_length);
 
     new_type = array_typet(
@@ -5121,25 +5190,34 @@ bool clarity_convertert::get_elementary_type_name(
         int_type()));
     break;
   }
-  case ClarityGrammar::ElementaryTypeNameT::ADDRESS:
+  case ClarityGrammar::ElementaryTypeNameT::PRINCIPAL:
   {
-    //  An Address is a DataHexString of 20 bytes (uint160)
-    // e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
-    // ops: <=, <, ==, !=, >= and >
+    /// obj[2] contains size of object
+    std::string str_value_length = objtype[2];
+    size_t value_length = std::stoi(str_value_length);
 
-    new_type = unsignedbv_typet(160);
+    if (value_length > 1)
+    {
+      log_error("Principal type can only have one byte");
+      return true;
+    }
+    else
+    {
+      new_type = array_typet(
+        signed_char_type(),
+        constant_exprt(
+          integer2binary(value_length, bv_width(int_type())),
+          integer2string(value_length),
+          int_type()));
 
-    // for type conversion
-    new_type.set("#clar_type", elementary_type_name_to_str(type));
-
-    break;
+      break;
+    }
   }
   case ClarityGrammar::ElementaryTypeNameT::BUFF:
   {
-  
-    if (get_elementary_type_name_bytesn(objtype, new_type))
-       return true;
-   
+    if (get_elementary_type_name_buff(objtype, new_type))
+      return true;
+
     // for type conversion
     //new_type.set("#clar_type", elementary_type_name_to_str(type));
     //new_type.set("#clar_bytes_size", bytesn_type_name_to_size(type));
@@ -5235,10 +5313,20 @@ void clarity_convertert::get_state_var_decl_name(
   // e.g. clar:@C@Base@x#11
   // The prefix is used to avoid duplicate names
   if (!contract_name.empty())
-    id = "clar:@C@" + contract_name + "@" + name + "#" +
-         i2string(ast_node[1]["cid"].get<std::int16_t>());
+  {
+    if (ClarityGrammar::is_tuple_declaration(ast_node))
+    {
+      get_tuple_name(ast_node, name, id);
+    }
+    else
+    {
+      id = "clar:@C@" + contract_name + "@" + name + "#" +
+           i2string(ast_node[1]["cid"].get<std::int16_t>());
+    }
+  }
   else
-    id = "clar:@" + name + "#" + i2string(ast_node[1]["cid"].get<std::int16_t>());
+    id =
+      "clar:@" + name + "#" + i2string(ast_node[1]["cid"].get<std::int16_t>());
 }
 
 // parse the non-state variable
@@ -5377,7 +5465,7 @@ unsigned int clarity_convertert::get_line_number(
   const nlohmann::json &ast_node,
   bool final_position)
 {
- /*
+  /*
  [
       "data-var",
       {
@@ -5411,7 +5499,7 @@ void clarity_convertert::get_location_from_decl(
 
   // To annotate local declaration within a function
   if (
-    ClarityGrammar::is_variable_declaration(ast_node)  &&
+    ClarityGrammar::is_variable_declaration(ast_node) &&
     ClarityGrammar::is_state_variable(ast_node) == false)
   {
     assert(
@@ -6139,7 +6227,7 @@ bool clarity_convertert::get_default_function(
   const std::string id)
 {
   nlohmann::json ast_node;
-  
+
   auto j2 = R"(
               [
                 "ParameterList",
@@ -6150,8 +6238,8 @@ bool clarity_convertert::get_default_function(
                 }
               ]
             )"_json;
-  
-  ast_node["returnParameters"] = j2 ; 
+
+  ast_node["returnParameters"] = j2;
   //std::cout << std::setw(4) << ast_node["returnParameters"] << "\n";
 
   code_typet type;
@@ -6233,16 +6321,14 @@ static inline void static_lifetime_init(const contextt &context, codet &dest)
   dest = code_blockt();
 
   // call designated "initialization" functions
-  context.foreach_operand_in_order(
-    [&dest](const symbolt &s)
+  context.foreach_operand_in_order([&dest](const symbolt &s) {
+    if (s.type.initialization() && s.type.is_code())
     {
-      if (s.type.initialization() && s.type.is_code())
-      {
-        code_function_callt function_call;
-        function_call.function() = symbol_expr(s);
-        dest.move_to_operands(function_call);
-      }
-    });
+      code_function_callt function_call;
+      function_call.function() = symbol_expr(s);
+      dest.move_to_operands(function_call);
+    }
+  });
 }
 
 // declare an empty array symbol and move it to the context
@@ -6364,11 +6450,11 @@ bool clarity_convertert::multi_transaction_verification(
 
   // 1. get constructor call
 
-
   //for (auto it = id_list.rbegin(); it != id_list.rend(); ++it)
   {
     // 1.1 get contract symbol ("tag-contractName")
-    std::string c_name = current_contractName; //exportedSymbolsList[*it];
+    std::string c_name;
+    get_current_contract_name(nullptr, c_name); //exportedSymbolsList[*it];
     const std::string id = prefix + c_name;
     if (context.find_symbol(id) == nullptr)
       return true;

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -33,8 +33,8 @@ clarity_convertert::clarity_convertert(
     current_contractName(""),
     scope_map({}),
     tgt_func(config.options.get_option("function")),
-    //tgt_cnt(config.options.get_option("contract"))
-    tgt_cnt("basic_dummy")
+    tgt_cnt(config.options.get_option("clar_contract"))
+    
 {
   std::ifstream in(_contract_path);
   contract_contents.assign(

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -204,6 +204,11 @@ void NewFunction(code_typet &type);
     const nlohmann::json &integer_literal,
     std::string the_value,
     exprt &dest);
+  
+  bool convert_unsigned_integer_literal(
+  const nlohmann::json &unsigned_integer_literal,
+  std::string the_value,
+  exprt &dest);
 
   bool convert_integer_literal_with_type(
   typet & type,

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -298,7 +298,7 @@ private:
     ClarityGrammar::ElementaryTypeNameT &type,
     typet &out);
   bool get_elementary_type_name_bytesn(
-    ClarityGrammar::ElementaryTypeNameT &type,
+    const nlohmann::json &objtype,
     typet &out);
 };
 

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -24,25 +24,24 @@ public:
     const std::string &_contract_path);
   virtual ~clarity_convertert() = default;
 
-
   bool convert();
 
 protected:
-
   //m-ali
-  bool process_expr_node(nlohmann::json & ast_node); 
-  bool process_define_data_var(nlohmann::json & ast_node);
-  bool process_define_constant(nlohmann::json & ast_node);
-  bool process_define_map(nlohmann::json & ast_node);
+  bool process_expr_node(nlohmann::json &ast_node);
+  bool process_define_data_var(nlohmann::json &ast_node);
+  bool process_define_constant(nlohmann::json &ast_node);
+  bool process_define_map(nlohmann::json &ast_node);
 
-
-  std::string get_objtype_type_name(const nlohmann::json & objtype_node);
-  std::string get_objtype_type_identifier(const nlohmann::json & objtype_node);
-  std::string get_objtype_type_size(const nlohmann::json & objtype_node);
-  void get_objtype_node(const nlohmann::json & ast_node, nlohmann::json & objtype_node);
-  bool check_valid_ast(const nlohmann::json & ast_node);
+  std::string get_objtype_type_name(const nlohmann::json &objtype_node);
+  std::string get_objtype_type_identifier(const nlohmann::json &objtype_node);
+  std::string get_objtype_type_size(const nlohmann::json &objtype_node);
+  void get_objtype_node(
+    const nlohmann::json &ast_node,
+    nlohmann::json &objtype_node);
+  bool check_valid_ast(const nlohmann::json &ast_node);
   void set_current_contract_name(std::string &contract_name);
-  bool parse_expression_element(const nlohmann::json & expr_element_json);
+  bool parse_expression_element(const nlohmann::json &expr_element_json);
 
   // dummy functions for learning
   void add_dummy_symbol();
@@ -51,7 +50,7 @@ protected:
   void add_dummy_builtin_functionCall();
   void add_function_definition_symboltable();
   // end-m-ali
-  
+
   bool convert_ast_nodes(const nlohmann::json &contract_def);
 
   // conversion functions
@@ -61,7 +60,7 @@ protected:
   bool get_var_decl_stmt(const nlohmann::json &ast_node, exprt &new_expr);
   bool get_var_decl(const nlohmann::json &ast_node, exprt &new_expr);
   bool get_function_definition(const nlohmann::json &ast_node);
-void NewFunction(code_typet &type);
+  void NewFunction(code_typet &type);
   bool get_function_params(const nlohmann::json &pd, exprt &param);
   bool get_default_function(const std::string name, const std::string id);
 
@@ -111,8 +110,7 @@ void NewFunction(code_typet &type);
   bool get_type_description(const nlohmann::json &type_name, typet &new_type);
   bool get_func_decl_ref_type(const nlohmann::json &decl, typet &new_type);
   bool get_array_to_pointer_type(const nlohmann::json &decl, typet &new_type);
-  bool
-  get_elementary_type_name(const nlohmann::json &objtype, typet &new_type);
+  bool get_elementary_type_name(const nlohmann::json &objtype, typet &new_type);
   bool get_parameter_list(const nlohmann::json &type_name, typet &new_type);
   void get_state_var_decl_name(
     const nlohmann::json &ast_node,
@@ -206,20 +204,20 @@ void NewFunction(code_typet &type);
     const nlohmann::json &integer_literal,
     std::string the_value,
     exprt &dest);
-  
+
   bool convert_unsigned_integer_literal(
-  const nlohmann::json &unsigned_integer_literal,
-  std::string the_value,
-  exprt &dest);
+    const nlohmann::json &unsigned_integer_literal,
+    std::string the_value,
+    exprt &dest);
 
   bool convert_integer_literal_with_type(
-  typet & type,
-  std::string the_value,
-  exprt &dest);
+    typet &type,
+    std::string the_value,
+    exprt &dest);
   bool convert_unsigned_integer_literal_with_type(
-  typet & type,
-  std::string the_value,
-  exprt &dest);
+    typet &type,
+    std::string the_value,
+    exprt &dest);
 
   bool convert_bool_literal(
     const nlohmann::json &bool_literal,
@@ -233,6 +231,7 @@ void NewFunction(code_typet &type);
     const nlohmann::json &integer_literal,
     std::string the_value,
     exprt &dest);
+
   // check if it's a bytes type
   bool is_bytes_type(const typet &t);
 
@@ -297,9 +296,10 @@ private:
   bool get_elementary_type_name_int(
     ClarityGrammar::ElementaryTypeNameT &type,
     typet &out);
-  bool get_elementary_type_name_bytesn(
-    const nlohmann::json &objtype,
-    typet &out);
+  bool
+  get_elementary_type_name_bytesn(const nlohmann::json &objtype, typet &out);
+
+  bool get_elementary_type_name_buff(const nlohmann::json &objtype, typet &out);
 };
 
 #endif /* CLARITY_FRONTEND_CLARITY_CONVERT_H_ */

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -34,14 +34,16 @@ protected:
   bool process_define_data_var(nlohmann::json & ast_node);
   bool process_define_constant(nlohmann::json & ast_node);
   bool process_define_map(nlohmann::json & ast_node);
-  void insert_dummy_objType(nlohmann::json & ast_node, std::string type_name, int type_size); 
-  bool is_state_variable(const nlohmann::json & ast_node);
-  bool is_variable_declaration(const nlohmann::json & ast_node);
+
+
   std::string get_objtype_type_name(const nlohmann::json & objtype_node);
   std::string get_objtype_type_identifier(const nlohmann::json & objtype_node);
   std::string get_objtype_type_size(const nlohmann::json & objtype_node);
   void get_objtype_node(const nlohmann::json & ast_node, nlohmann::json & objtype_node);
-  
+  bool check_valid_ast(const nlohmann::json & ast_node);
+  void set_current_contract_name(std::string &contract_name);
+  bool parse_expression_element(const nlohmann::json & expr_element_json);
+
   // dummy functions for learning
   void add_dummy_symbol();
   void convert_dummy_uint_literal();
@@ -110,7 +112,7 @@ void NewFunction(code_typet &type);
   bool get_func_decl_ref_type(const nlohmann::json &decl, typet &new_type);
   bool get_array_to_pointer_type(const nlohmann::json &decl, typet &new_type);
   bool
-  get_elementary_type_name(const nlohmann::json &type_name, typet &new_type);
+  get_elementary_type_name(const nlohmann::json &objtype, typet &new_type);
   bool get_parameter_list(const nlohmann::json &type_name, typet &new_type);
   void get_state_var_decl_name(
     const nlohmann::json &ast_node,

--- a/src/clarity-frontend/clarity_convert_literals.cpp
+++ b/src/clarity-frontend/clarity_convert_literals.cpp
@@ -196,7 +196,7 @@ bool clarity_convertert::convert_uint_literal(
       the_value.erase(0, 1);
     }
  
-  convert_integer_literal(uint_literal, the_value, dest);
+  convert_unsigned_integer_literal(uint_literal, the_value, dest);
   return false;
 }
 // TODO: Float literal.

--- a/src/clarity-frontend/clarity_convert_literals.cpp
+++ b/src/clarity-frontend/clarity_convert_literals.cpp
@@ -16,7 +16,7 @@ bool clarity_convertert::convert_integer_literal(
 {
   // clarity only supports 128 bit signed integers
   typet type = signedbv_typet(128);
-  
+
   exprt the_val;
   // extract the value: signed
   BigInt z_ext_value = string2integer(the_value);
@@ -36,7 +36,7 @@ bool clarity_convertert::convert_unsigned_integer_literal(
 {
   // clarity only supports 128 bit unsigned integers
   typet type = unsignedbv_typet(128);
-  
+
   exprt the_val;
   // extract the value: signed
   BigInt z_ext_value = string2integer(the_value);
@@ -52,11 +52,10 @@ bool clarity_convertert::convert_unsigned_integer_literal(
 // can probably be ignored.
 // use convert_integer_literal instead.
 bool clarity_convertert::convert_integer_literal_with_type(
-  typet & type,
+  typet &type,
   std::string the_value,
   exprt &dest)
 {
-
   if (type != signedbv_typet(128))
   {
     //std::cout <<"invalid type provided. "<<"Expected "<<"signedbv_typet \n";
@@ -75,17 +74,16 @@ bool clarity_convertert::convert_integer_literal_with_type(
 }
 
 bool clarity_convertert::convert_unsigned_integer_literal_with_type(
-  typet & type,
+  typet &type,
   std::string the_value,
   exprt &dest)
 {
-
   if (type != unsignedbv_typet(128))
   {
     //std::cout <<"invalid type provided. "<<"Expected "<<"unsignedbv_typet \n";
     abort();
   }
-    
+
   exprt the_val;
   // extract the value: unsigned
   BigInt z_ext_value = string2integer(the_value);
@@ -97,7 +95,6 @@ bool clarity_convertert::convert_unsigned_integer_literal_with_type(
   dest.swap(the_val);
   return false;
 }
-
 
 bool clarity_convertert::convert_bool_literal(
   const nlohmann::json &bool_literal,
@@ -135,7 +132,7 @@ bool clarity_convertert::convert_string_literal(
   std::string the_value,
   exprt &dest)
 {
-  size_t string_size = the_value.size() + 1;  //to accommodate \0
+  size_t string_size = the_value.size() + 1; //to accommodate \0
   typet type = array_typet(
     signed_char_type(),
     constant_exprt(
@@ -178,7 +175,6 @@ bool clarity_convertert::convert_hex_literal(
   return false;
 }
 
-
 /**
  * convert str-string to uint constant
  * @n: the bit width, default 256 (unsignedbv_typet(256))
@@ -195,7 +191,7 @@ bool clarity_convertert::convert_uint_literal(
     {
       the_value.erase(0, 1);
     }
- 
+
   convert_unsigned_integer_literal(uint_literal, the_value, dest);
   return false;
 }

--- a/src/clarity-frontend/clarity_convert_literals.cpp
+++ b/src/clarity-frontend/clarity_convert_literals.cpp
@@ -8,17 +8,17 @@
 #include <util/std_expr.h>
 
 // Integer literal
+// first argument : integer_literal is not used in Clarity frontend, but left for compatibility with other frontends
 bool clarity_convertert::convert_integer_literal(
   const nlohmann::json &integer_literal,
   std::string the_value,
   exprt &dest)
 {
-  typet type;
-  if (get_type_description(integer_literal, type))
-    return true;
-
+  // clarity only supports 128 bit signed integers
+  typet type = signedbv_typet(128);
+  
   exprt the_val;
-  // extract the value: unsigned
+  // extract the value: signed
   BigInt z_ext_value = string2integer(the_value);
   the_val = constant_exprt(
     integer2binary(z_ext_value, bv_width(type)),
@@ -29,6 +29,28 @@ bool clarity_convertert::convert_integer_literal(
   return false;
 }
 
+bool clarity_convertert::convert_unsigned_integer_literal(
+  const nlohmann::json &unsigned_integer_literal,
+  std::string the_value,
+  exprt &dest)
+{
+  // clarity only supports 128 bit unsigned integers
+  typet type = unsignedbv_typet(128);
+  
+  exprt the_val;
+  // extract the value: signed
+  BigInt z_ext_value = string2integer(the_value);
+  the_val = constant_exprt(
+    integer2binary(z_ext_value, bv_width(type)),
+    integer2string(z_ext_value),
+    type);
+
+  dest.swap(the_val);
+  return false;
+}
+
+// can probably be ignored.
+// use convert_integer_literal instead.
 bool clarity_convertert::convert_integer_literal_with_type(
   typet & type,
   std::string the_value,

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -34,80 +34,121 @@ const std::unordered_map<std::string, ElementaryTypeNameT> bytesn_to_type_map =
 const std::map<ElementaryTypeNameT, unsigned int> bytesn_size_map = {
   {BUFF, 32},
   {UINT_LITERAL, 128},
-  {INT_LITERAL, 128}
-};
+  {INT_LITERAL, 128}};
 
-bool is_state_variable(const nlohmann::json & ast_node)
+bool is_state_variable(const nlohmann::json &ast_node)
 {
-  const std::vector<std::string> state_node_types {"data-var" , "map" , "trait" , "constant" , "def-ft" , "def-nft"};
-  
-  if (std::find(state_node_types.begin(), state_node_types.end(), ast_node[0]) != state_node_types.end())
+  const std::vector<std::string> state_node_types{
+    "data-var", "map", "trait", "constant", "def-ft", "def-nft"};
+
+  if (
+    std::find(state_node_types.begin(), state_node_types.end(), ast_node[0]) !=
+    state_node_types.end())
     return true;
   else
     return false;
 }
 
-bool is_variable_declaration(const nlohmann::json & ast_node)
+bool is_tuple_declaration(const nlohmann::json &ast_node)
 {
-  
+  if (ast_node[1]["objtype"][0] == "tuple")
+    return true;
+  else
+    return false;
+}
+
+bool is_variable_declaration(const nlohmann::json &ast_node)
+{
   return is_state_variable(ast_node);
 }
 
-bool is_function_definition(const nlohmann::json & ast_node)
+bool is_function_definition(const nlohmann::json &ast_node)
 {
-  const std::vector<std::string> state_node_types {"var-get" , "read-only" , "private" , "public"};
-  
-  if (std::find(state_node_types.begin(), state_node_types.end(), ast_node[0]) != state_node_types.end())
+  const std::vector<std::string> state_node_types{
+    "var-get", "read-only", "private", "public"};
+
+  if (
+    std::find(state_node_types.begin(), state_node_types.end(), ast_node[0]) !=
+    state_node_types.end())
     return true;
   else
     return false;
 }
 
-bool operation_is_binary(const nlohmann::json & ast_node)
+bool operation_is_binary(const nlohmann::json &ast_node)
 {
-  const std::vector<std::string> binary_operators {"+", "-", "*", "/", "%", "<<", ">>", "&", "|", ">", "<", ">=", "<=", "!=", "==", "&&", "||", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", "&=", "|=", "^=", "**"};
-  
-  if (std::find(binary_operators.begin(), binary_operators.end(), ast_node[0]) != binary_operators.end())
+  const std::vector<std::string> binary_operators{
+    "+",  "-",  "*",   "/",   "%",  "<<", ">>", "&",  "|",  ">",
+    "<",  ">=", "<=",  "!=",  "==", "&&", "||", "+=", "-=", "*=",
+    "/=", "%=", "<<=", ">>=", "&=", "|=", "^=", "**"};
+
+  if (
+    std::find(binary_operators.begin(), binary_operators.end(), ast_node[0]) !=
+    binary_operators.end())
     return true;
   else
     return false;
 }
 
-bool operation_is_unary(const nlohmann::json & ast_node)
+bool operation_is_unary(const nlohmann::json &ast_node)
 {
-  const std::vector<std::string> unary_operators {"--", "++", "-", "~", "!"};
-  
-  if (std::find(unary_operators.begin(), unary_operators.end(), ast_node[0]) != unary_operators.end())
+  const std::vector<std::string> unary_operators{"--", "++", "-", "~", "!"};
+
+  if (
+    std::find(unary_operators.begin(), unary_operators.end(), ast_node[0]) !=
+    unary_operators.end())
     return true;
   else
     return false;
 }
 
-bool operation_is_conditional(const nlohmann::json & ast_node)
+bool operation_is_optional(const nlohmann::json &ast_node)
 {
-  const std::vector<std::string> conditional_operators {"if"};
-  
-  if (std::find(conditional_operators.begin(), conditional_operators.end(), ast_node[0]) != conditional_operators.end())
+  const std::vector<std::string> conditional_operators{"some"};
+
+  if (
+    std::find(
+      conditional_operators.begin(),
+      conditional_operators.end(),
+      ast_node[0]) != conditional_operators.end())
     return true;
   else
     return false;
 }
 
-bool get_operation_type(nlohmann::json & expression_node)
+bool operation_is_conditional(const nlohmann::json &ast_node)
+{
+  const std::vector<std::string> conditional_operators{"if"};
+
+  if (
+    std::find(
+      conditional_operators.begin(),
+      conditional_operators.end(),
+      ast_node[0]) != conditional_operators.end())
+    return true;
+  else
+    return false;
+}
+
+bool get_operation_type(nlohmann::json &expression_node)
 {
   nlohmann::json value_node = expression_node[1]["value"];
 
   if (operation_is_binary(value_node))
   {
-     expression_node[1]["expressionType"] = "BinaryOperation";
+    expression_node[1]["expressionType"] = "BinaryOperation";
   }
   else if (operation_is_unary(value_node))
   {
     expression_node[1]["expressionType"] = "UnaryOperation";
   }
-  else if(operation_is_conditional(value_node))
+  else if (operation_is_conditional(value_node))
   {
     expression_node[1]["expressionType"] = "Conditional";
+  }
+  else if (value_node[0] == "tuple")
+  {
+    expression_node[1]["expressionType"] = "TupleExpression";
   }
   else
   {
@@ -115,9 +156,9 @@ bool get_operation_type(nlohmann::json & expression_node)
     return true; // unexpected
   }
 
-  return false;  
+  return false;
 
- /*
+  /*
   else if (nodeType == "TupleExpression")
   {
     return Tuple;
@@ -131,13 +172,14 @@ bool get_operation_type(nlohmann::json & expression_node)
     */
 }
 
-bool parse_value_node(nlohmann::json & expression_node)
+bool parse_value_node(nlohmann::json &expression_node)
 {
   // parse value node
   nlohmann::json value_node = expression_node[1]["value"];
   std::string value_type = value_node.type_name();
 
-  if (value_type == "string" || value_type == "number" || value_type == "object")
+  if (
+    value_type == "string" || value_type == "number" || value_type == "object")
   {
     // it's a literal value
     //
@@ -148,21 +190,16 @@ bool parse_value_node(nlohmann::json & expression_node)
     }
     else
     {
-
     }
-    
   }
   else if (value_type == "array")
   {
     // it's a function call with arguments
-    
 
     if (get_operation_type(expression_node))
     {
       return true;
     }
-
-    
   }
   else
   {
@@ -170,18 +207,17 @@ bool parse_value_node(nlohmann::json & expression_node)
     return false;
   }
 
-
   return false;
 }
 
-bool parse_expression_element(nlohmann::json & expr_element_json)
+bool parse_expression_element(nlohmann::json &expr_element_json)
 {
   std::string expression_class = expr_element_json[0];
 
   // determine if it's a variable / constant declaration or a function definition
   bool var_decl = is_variable_declaration(expr_element_json);
   bool func_def = is_function_definition(expr_element_json);
-  
+
   // add a nodeType for easier differenciation down the line.
   if (var_decl)
   {
@@ -201,7 +237,6 @@ bool parse_expression_element(nlohmann::json & expr_element_json)
     return true;
   }
 
-
   // parse value node
   parse_value_node(expr_element_json);
 
@@ -210,12 +245,11 @@ bool parse_expression_element(nlohmann::json & expr_element_json)
 // rule contract-body-element
 ContractBodyElementT get_contract_body_element_t(const nlohmann::json &element)
 {
-  if (element[1]["nodeType"] == "VariableDeclaration") 
+  if (element[1]["nodeType"] == "VariableDeclaration")
   {
     return VarDecl;
   }
-  else if (
-    element[1]["nodeType"] == "FunctionDefinition")
+  else if (element[1]["nodeType"] == "FunctionDefinition")
   {
     return FunctionDef;
   }
@@ -251,19 +285,19 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
 {
   // Clarity AST node has type stored in ast_node[1]["objtype"] as [ "typeName","typeIdentifier" , "size"]
   //! Order matters
-   
-    const std::string typeString = type_name[0];      //type name
-    const std::string typeIdentifier = type_name[1];  //type identifier
-    
+
+  const std::string typeString = type_name[0]; //type name
+  const std::string typeIdentifier =
+    ""; //FIXME: we can't have type_name[1];  as it's not valid for tuples
+
   if (typeString != "ParameterList") // if (type_name.contains("typeString"))
   {
-   
-      //type_name["typeIdentifier"].get<std::string>();
+    //type_name["typeIdentifier"].get<std::string>();
 
     // we must first handle tuple
     // otherwise we might parse tuple(literal_string, literal_string)
     // as ElementaryTypeName
-    if (typeString.compare(0, 6, "tuple(") == 0)
+    if (typeString == "tuple")
     {
       return TupleTypeName;
     }
@@ -273,22 +307,21 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
     }
     else if (typeString == "buff")
     {
-     //buff in clarity can be considered as array of bytes
+      //buff in clarity can be considered as array of bytes
 
       return BuffTypeName;
     }
     else if (typeString == "list")
     {
-     //buff in clarity can be considered as array of bytes
+      //list in clarity can be considered as array of bytes
 
       return ArrayTypeName;
     }
     else if (
       uint_string_to_type_map.count(typeString) ||
       int_string_to_type_map.count(typeString) || typeString == "bool" ||
-      typeString== "string-ascii" ||
-      typeString == "string-utf8" ||
-      typeString == "principal") 
+      typeString == "string-ascii" || typeString == "string-utf8" ||
+      typeString == "principal")
     {
       // For state var declaration,
       return ElementaryTypeName;
@@ -324,9 +357,9 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
   {
     // for AST node that does not contain ["typeDescriptions"] only
     // function returnParameters
-    
-      return ParameterList;
-    
+
+    return ParameterList;
+
     // else
     // {
     //   log_error(
@@ -362,10 +395,11 @@ const char *type_name_to_str(TypeNameT type)
 
 // rule elementary-type-name
 // return the type of expression
-// takes objtype node as input 
+// takes objtype node as input
 ElementaryTypeNameT get_elementary_type_name_t(const nlohmann::json &type_name)
 {
-  std::string typeString =  type_name[0]; //type_name["typeString"].get<std::string>();
+  std::string typeString =
+    type_name[0]; //type_name["typeString"].get<std::string>();
   // rule unsigned-integer-type
 
   if (uint_string_to_type_map.count(typeString))
@@ -379,7 +413,6 @@ ElementaryTypeNameT get_elementary_type_name_t(const nlohmann::json &type_name)
   if (typeString == "bool")
   {
     return BOOL;
-  
   }
   if (typeString.find("uint_const") != std::string::npos)
   {
@@ -420,9 +453,9 @@ ElementaryTypeNameT get_elementary_type_name_t(const nlohmann::json &type_name)
     // TODO
     return STRING_UTF8;
   }
-  if (typeString == "address")
+  if (typeString == "principal")
   {
-    return ADDRESS;
+    return PRINCIPAL;
   }
   if (bytesn_to_type_map.count(typeString))
   {
@@ -431,7 +464,6 @@ ElementaryTypeNameT get_elementary_type_name_t(const nlohmann::json &type_name)
   }
   if (typeString.find("buff") != std::string::npos)
   {
-
     return BUFF;
   }
   log_error(
@@ -450,7 +482,7 @@ const char *elementary_type_name_to_str(ElementaryTypeNameT type)
     ENUM_TO_STR(INT)
     ENUM_TO_STR(INT_LITERAL)
     ENUM_TO_STR(BOOL)
-    ENUM_TO_STR(ADDRESS)
+    ENUM_TO_STR(PRINCIPAL)
     ENUM_TO_STR(STRING_ASCII)
     ENUM_TO_STR(STRING_ASCII_LITERAL)
     ENUM_TO_STR(STRING_UTF8)
@@ -640,15 +672,14 @@ const char *statement_to_str(StatementT type)
 // rule expression
 ExpressionT get_expression_t(const nlohmann::json &expr)
 {
-  
   if (expr.is_null())
   {
     return NullExpr;
   }
-  
+
   std::string nodeType = expr[1]["expressionType"];
 
-  if (nodeType == "Assignment" || nodeType == "BinaryOperation" )
+  if (nodeType == "Assignment" || nodeType == "BinaryOperation")
   {
     return BinaryOperatorClass;
   }
@@ -660,8 +691,7 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   {
     return ConditionalOperatorClass;
   }
-  else if (
-    nodeType == "Identifier" && expr.contains("referencedDeclaration"))
+  else if (nodeType == "Identifier" && expr.contains("referencedDeclaration"))
   {
     return DeclRefExprClass;
   }
@@ -711,8 +741,7 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   else
   {
     log_error(
-      "Got expression nodeType={}. Unsupported expression type",
-      nodeType);
+      "Got expression nodeType={}. Unsupported expression type", nodeType);
     abort();
   }
   return ExpressionTError;

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -271,27 +271,15 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
     {
       return MappingTypeName;
     }
-    else if (typeIdentifier.find("t_array$") != std::string::npos)
+    else if (typeString == "buff")
     {
-      // Clarity's array type description is like:
-      //  "typeIdentifier": "t_array$_t_uint8_$2_memory_ptr",
-      //  "typeString": "uint8[2] memory"
+     //buff in clarity can be considered as array of bytes
 
-      // The Arrays in Clarity can be classified into the following two types based on size –
-      //   Fixed Size Array
-      //   Dynamic Array
-      // Furthermore, the clarity array can also be categorized based on where they are stored as –
-      //   Storage Array
-      //   Memory Array
-
-      // Multi-Dimensional Arrays
-      if (typeIdentifier.find("t_array$_t_array$") != std::string::npos)
-      {
-        log_error("Multi-Dimensional Arrays are not supported.");
-        abort();
-      }
-
-     
+      return BuffTypeName;
+    }
+    else if (typeString == "list")
+    {
+     //buff in clarity can be considered as array of bytes
 
       return ArrayTypeName;
     }
@@ -443,12 +431,7 @@ ElementaryTypeNameT get_elementary_type_name_t(const nlohmann::json &type_name)
   }
   if (typeString.find("buff") != std::string::npos)
   {
-    // dynamic bytes array
-    // e.g.
-    //    bytes
-    //    bytes storage ref
-    //    bytes memory
-    // TODO
+
     return BUFF;
   }
   log_error(

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -19,17 +19,16 @@ enum ContractBodyElementT
 ContractBodyElementT get_contract_body_element_t(const nlohmann::json &element);
 const char *contract_body_element_to_str(ContractBodyElementT type);
 
-
-
 /* m-ali */
-  bool is_state_variable(const nlohmann::json & ast_node);
-  bool is_variable_declaration(const nlohmann::json & ast_node);
-  bool is_function_definitionn(const nlohmann::json & ast_node);
-  bool parse_expression_element(nlohmann::json & expr_element_json);
-  bool get_operation_type(nlohmann::json & expression_node);
-  bool operation_is_conditional(const nlohmann::json & ast_node);
-  bool operation_is_unary(const nlohmann::json & ast_node);
-  bool operation_is_binary(const nlohmann::json & ast_node);
+bool is_state_variable(const nlohmann::json &ast_node);
+bool is_variable_declaration(const nlohmann::json &ast_node);
+bool is_function_definitionn(const nlohmann::json &ast_node);
+bool is_tuple_declaration(const nlohmann::json &ast_node);
+bool parse_expression_element(nlohmann::json &expr_element_json);
+bool get_operation_type(nlohmann::json &expression_node);
+bool operation_is_conditional(const nlohmann::json &ast_node);
+bool operation_is_unary(const nlohmann::json &ast_node);
+bool operation_is_binary(const nlohmann::json &ast_node);
 
 /* end m-ali*/
 
@@ -41,7 +40,6 @@ enum TypeNameT
 
   // rule parameter-list. Strictly, this should not be here. Just a workaround
   ParameterList,
-
 
   // static array type
   ArrayTypeName,
@@ -81,7 +79,7 @@ enum ElementaryTypeNameT
   BOOL,
 
   // rule address
-  ADDRESS,
+  PRINCIPAL,
 
   // rule string
   // TODO: it's always (string-ascii <max-size>) or (string-utf8 <max-size>)

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -19,6 +19,20 @@ enum ContractBodyElementT
 ContractBodyElementT get_contract_body_element_t(const nlohmann::json &element);
 const char *contract_body_element_to_str(ContractBodyElementT type);
 
+
+
+/* m-ali */
+  bool is_state_variable(const nlohmann::json & ast_node);
+  bool is_variable_declaration(const nlohmann::json & ast_node);
+  bool is_function_definitionn(const nlohmann::json & ast_node);
+  bool parse_expression_element(nlohmann::json & expr_element_json);
+  bool get_operation_type(nlohmann::json & expression_node);
+  bool operation_is_conditional(const nlohmann::json & ast_node);
+  bool operation_is_unary(const nlohmann::json & ast_node);
+  bool operation_is_binary(const nlohmann::json & ast_node);
+
+/* end m-ali*/
+
 // rule type-name
 enum TypeNameT
 {
@@ -28,17 +42,11 @@ enum TypeNameT
   // rule parameter-list. Strictly, this should not be here. Just a workaround
   ParameterList,
 
-  // auxiliary type for FunctionToPointer decay in CallExpr when making a function call
-  Pointer, // TODO: Fix me. Rename it to PointerFuncToPtr
-
-  // auxiliary type for ArrayToPointer when dereferencing array, e.g. a[0]
-  PointerArrayToPtr,
 
   // static array type
   ArrayTypeName,
 
-  // dynamic array type
-  DynArrayTypeName,
+  
 
   // contract type
   ContractTypeName,

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -46,7 +46,7 @@ enum TypeNameT
   // static array type
   ArrayTypeName,
 
-  
+  BuffTypeName,
 
   // contract type
   ContractTypeName,

--- a/src/clarity-frontend/clarity_language.cpp
+++ b/src/clarity-frontend/clarity_language.cpp
@@ -25,7 +25,6 @@ clarity_languaget::clarity_languaget()
   if (!fun.empty())
     func_name = fun;
 
-
   std::string clar = config.options.get_option("clar");
   if (clar.empty())
 
@@ -75,7 +74,9 @@ bool clarity_languaget::parse(const std::string &path)
   // get AST nodes of ESBMC intrinsics and the dummy main
   // populate ASTs inherited from parent class
   auto clar_lang = std::exchange(config.language, {language_idt::C, ""});
-  clang_c_languaget::parse(temp_path);
+  if (clang_c_languaget::parse(temp_path))
+    return true;
+
   config.language = std::move(clar_lang);
 
   // Process AST json file
@@ -114,8 +115,7 @@ bool clarity_languaget::parse(const std::string &path)
   return false;
 }
 
-
-// ToDo : to review this function 
+// ToDo : to review this function
 bool clarity_languaget::convert_intrinsics(contextt &context)
 {
   clang_c_convertert converter(context, AST, "C++");
@@ -131,12 +131,10 @@ bool clarity_languaget::typecheck(contextt &context, const std::string &module)
   convert_intrinsics(
     new_context); // Add ESBMC and TACAS intrinsic symbols to the context
 
-
   clarity_convertert converter(
     new_context, src_ast_json, func_name, smart_contract);
   if (converter.convert()) // Add Clarity symbols to the context
     return true;
-
 
   // migrate from clang_c_adjust to clang_cpp_adjust
   // for the reason that we need clang_cpp_adjust::adjust_side_effect

--- a/src/clarity-frontend/clarity_template.h
+++ b/src/clarity-frontend/clarity_template.h
@@ -31,8 +31,8 @@ const std::string clar_header = R"(
 	see https://docs.stacks.co/clarity/functions#principal-destruct
 */
 const std::string clar_typedef = R"(
-typedef signed _ExtInt(128) int128_t;
-typedef unsigned _ExtInt(128) uint128_t;
+typedef signed _BitInt(128) int128_t;
+typedef unsigned _BitInt(128) uint128_t;
 
 #define CLARITY_ADDRESS_TYPE_STANDARD 1
 #define CLARITY_ADDRESS_TYPE_CONTRACT 2
@@ -51,10 +51,10 @@ typedef struct {
 #  if 0
 TODO: not used
 const std::string clar_msg = R"(
-uint256_t msg_data;
+uint128_t msg_data;
 address_t msg_address;
 __uint32_t msg_sig;
-uint256_t msg_value;
+uint128_t msg_value;
 )";
 #  endif
 
@@ -68,14 +68,14 @@ address_t tx_sponsorM;
 TODO: some of this is in https://docs.stacks.co/clarity/functions#get-block-info
 
 const std::string clar_block = R"(
-uint256_t block_basefee;
-uint256_t block_chainid;
+uint128_t block_basefee;
+uint128_t block_chainid;
 address_t block_coinbase;
-uint256_t block_difficulty;
-uint256_t block_gaslimit;
-uint256_t block_number;
-uint256_t block_prevrandao;
-uint256_t block_timestamp;
+uint128_t block_difficulty;
+uint128_t block_gaslimit;
+uint128_t block_number;
+uint128_t block_prevrandao;
+uint128_t block_timestamp;
 )";
 #  endif
 
@@ -89,34 +89,34 @@ const std::string clar_vars = clar_tx;
 // https://docs.soliditylang.org/en/latest/units-and-global-variables.html#special-variables-and-functions
 
 const std::string blockhash = R"(
-uint256_t blockhash();
+uint128_t blockhash();
 )";
 
 const std::string gasleft = R"(
-uint256_t gasleft();
+uint128_t gasleft();
 )";
 
 const std::string clar_abi = R"(
-uint256_t abi_encode();
-uint256_t abi_encodePacked();
-uint256_t abi_encodeWithSelector();
-uint256_t abi_encodeWithSignature();
-uint256_t abi_encodeCall();
+uint128_t abi_encode();
+uint128_t abi_encodePacked();
+uint128_t abi_encodeWithSelector();
+uint128_t abi_encodeWithSignature();
+uint128_t abi_encodeCall();
 )";
 
 const std::string clar_math = R"(
-uint256_t addmod(uint256_t x, uint256_t y, uint256_t k)
+uint128_t addmod(uint128_t x, uint128_t y, uint128_t k)
 {
 	return (x + y) % k;
 }
 
-uint256_t mulmod(uint256_t x, uint256_t y, uint256_t k)
+uint128_t mulmod(uint128_t x, uint128_t y, uint128_t k)
 {
 	return (x * y) % k;
 }
 
-uint256_t keccak256();
-uint256_t sha256();
+uint128_t keccak256();
+uint128_t sha256();
 address_t ripemd160();
 address_t ecrecover();
 )";

--- a/src/clarity-frontend/pattern_check.cpp
+++ b/src/clarity-frontend/pattern_check.cpp
@@ -133,7 +133,7 @@ void pattern_checker::check_require_argument(const nlohmann::json &call_args)
         check_tx_origin(left_expr);
       }
     } // end of "=="
-  } // end of "BinaryOperation"
+  }   // end of "BinaryOperation"
 }
 
 /* TODO */

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -70,21 +70,22 @@ const struct group_opt_templ all_cmd_options[] = {
 #endif
 #ifdef ENABLE_CLARITY_FRONTEND
   {"Clarity frontend",
-   {{"clar",
-     boost::program_options::value<std::string>()->value_name("path"),
-     ".clarast file name"},
-    {"clar_contract",
-     boost::program_options::value<std::string>()->value_name("cname"),
-     "set contract name"},
-#if 0
+   {
+     {"clar",
+      boost::program_options::value<std::string>()->value_name("path"),
+      ".clarast file name"},
+     {"clar_contract",
+      boost::program_options::value<std::string>()->value_name("cname"),
+      "set contract name"},
+#  if 0
     TODO
 
     {"no-visibility",
      NULL,
      "force to verify every function, even it's an unreachable "
      "internal/private function"}
-#endif
-    }},
+#  endif
+   }},
 #endif
   {"Frontend",
    {{"include,I",

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -73,7 +73,7 @@ const struct group_opt_templ all_cmd_options[] = {
    {{"clar",
      boost::program_options::value<std::string>()->value_name("path"),
      ".clarast file name"},
-    {"contract",
+    {"clar_contract",
      boost::program_options::value<std::string>()->value_name("cname"),
      "set contract name"},
 #if 0


### PR DESCRIPTION
Sets up a skeleton to follow for further development.
Uses Solidity frontend code to minimise code changes.

Supports converting "data-var" of types uint, uint_literal, int, int_literal, string-ascii, string-utf8 and buff

takes input params in the following order
./esbmc --clar contractfile.clar contractfile.clarast --clar_contract contract_name

Follows Pseudocode for parsing F3 AST

F3 AST code can be found in ast-parser directory in clara_llm repo.