### PR TITLE
feat : composite types with new AST

### DIFF
--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -5286,6 +5286,7 @@ bool clarity_convertert::get_principal_instance(
 
     // manually create a member_name
     const std::string mem_name = key; //it.key();
+    std::string node_type ;
 
     /* Create a temporary JSON object to ease processing */
     nlohmann::json temp_expression_node;
@@ -5295,11 +5296,13 @@ bool clarity_convertert::get_principal_instance(
     {
       temp_expression_node["identifier"] = (ClarityGrammar::is_expression_standard_principal(expression_value_node)?"false":"true");
       value_type = "bool";
+      node_type = "lit_bool";
     }
     else if (key == "contract_is_standard")
     {
       temp_expression_node["identifier"] = (ClarityGrammar::is_expression_standard_principal(expression_value_node)?"true":"false");
       value_type = "bool";
+      node_type = "lit_bool";
     }
     else if (key == "contract_name")
     {
@@ -5328,6 +5331,7 @@ bool clarity_convertert::get_principal_instance(
       
       temp_expression_node["identifier"] = ClarityGrammar::get_expression_identifier(expression_value_node);
       value_type = "string-ascii";
+      node_type = "lit_ascii";
     }
 
     // get type
@@ -5335,7 +5339,7 @@ bool clarity_convertert::get_principal_instance(
     nlohmann::json objtype = {
       value_type, value_type, value_size}; //{value[0],value[0],value[2]};
 
-    temp_expression_node["type"] = "lit_bool";
+    temp_expression_node["type"] = node_type;
     temp_expression_node["span"] = ClarityGrammar::get_location_info(expression_value_node);
     //temp_expression_node["identifier"] = mem_name;
     temp_expression_node["cid"] = ClarityGrammar::get_expression_cid(expression_value_node);
@@ -5344,7 +5348,7 @@ bool clarity_convertert::get_principal_instance(
     
 
     //nlohmann::json temp_declarative_node = {"principal", temp_expression_node};
-    std::cout <<temp_expression_node.dump(4)<<std::endl;
+    //std::cout <<temp_expression_node.dump(4)<<std::endl;
     exprt init;
     if (get_expr(temp_expression_node, objtype, init))
       return true;

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -3069,8 +3069,6 @@ bool clarity_convertert::get_expr(
 
     break;
   }
-// ml- [TODO] deal with the rest of the expression types  
-#if 0
   case ClarityGrammar::ExpressionT::Tuple:
   {
     /*
@@ -3091,142 +3089,15 @@ bool clarity_convertert::get_expr(
     if (get_tuple_instance(expr, new_expr))
       return true;
 
-    // older code : has useful comments to read
-    // assert(expr.contains("components"));
-
-    // switch (type)
-    // {
-    // // case 1
-    // case ClarityGrammar::TypeNameT::ArrayTypeName:
-    // {
-    //   assert(literal_type != nullptr);
-
-    //   // get elem type
-    //   nlohmann::json elem_literal_type =
-    //     make_array_elementary_type(literal_type);
-
-    //   // get size
-    //   exprt size;
-    //   size = constant_exprt(
-    //     integer2binary(expr["components"].size(), bv_width(int_type())),
-    //     integer2string(expr["components"].size()),
-    //     int_type());
-
-    //   // get array type
-    //   typet arr_type;
-    //   if (get_type_description(literal_type, arr_type))
-    //     return true;
-
-    //   // reallocate array size
-    //   arr_type = array_typet(arr_type.subtype(), size);
-
-    //   // declare static array tuple
-    //   exprt inits;
-    //   inits = gen_zero(arr_type);
-
-    //   // populate array
-    //   int i = 0;
-    //   for (const auto &arg : expr["components"].items())
-    //   {
-    //     exprt init;
-    //     if (get_expr(arg.value(), elem_literal_type, init))
-    //       return true;
-
-    //     inits.operands().at(i) = init;
-    //     i++;
-    //   }
-
-    //   new_expr = inits;
-    //   break;
-    // }
-
-    // // case 3
-    // case ClarityGrammar::TypeNameT::TupleTypeName: // case 3
-    // {
-    //   /*
-    //   we assume there are three types of tuple expr:
-    //   0. dump: (x,y);
-    //   1. fixed: (x,y) = (y,x);
-    //   2. function-related:
-    //       2.1. (x,y) = func();
-    //       2.2. return (x,y);
-
-    //   case 0:
-    //     1. create a struct type
-    //     2. create a struct type instance
-    //     3. new_expr = instance
-    //     e.g.
-    //     (x , y) ==>
-    //     struct Tuple
-    //     {
-    //       uint x,
-    //       uint y
-    //     };
-    //     Tuple tuple;
-
-    //   case 1:
-    //     1. add special handling in binary operation.
-    //        when matching struct_expr A = struct_expr B,
-    //        divided into A.operands()[i] = B.operands()[i]
-    //        and populated into a code_block.
-    //     2. new_expr = code_block
-    //     e.g.
-    //     (x, y) = (1, 2) ==>
-    //     {
-    //       tuple.x = 1;
-    //       tuple.y = 2;
-    //     }
-    //     ? any potential scope issue?
-
-    //   case 2:
-    //     1. when parsing the funciton definition, if the returnParam > 1
-    //        make the function return void instead, and create a struct type
-    //     2. when parsing the return statement, if the return value is a tuple,
-    //        create a struct type instance, do assignments,  and return empty;
-    //     3. when the lhs is tuple and rhs is func_call, get_tuple_instance_expr based
-    //        on the func_call, and do case 1.
-    //     e.g.
-    //     function test() returns (uint, uint)
-    //     {
-    //       return (1,2);
-    //     }
-    //     ==>
-    //     struct Tuple
-    //     {
-    //       uint x;
-    //       uint y;
-    //     }
-    //     function test()
-    //     {
-    //       Tuple tuple;
-    //       tuple.x = 1;
-    //       tuple.y = 2;
-    //       return;
-    //     }
-    //   */
-
-    //   // 1. construct struct type
-    //   if (get_tuple_definition(expr))
-    //     return true;
-
-    //   //2. construct struct_type instance
-    //   if (get_tuple_instance(expr, new_expr))
-    //     return true;
-
-    //   break;
-    // }
-
-    // // case 2
-    // default:
-    // {
-    //   if (get_expr(expr["components"][0], literal_type, new_expr))
-    //     return true;
-    //   break;
-    // }
-    // }
+   // if you find yourself in trouble, refer to Solidity frontend code for this same code.
+   // or check any code before 22nd Aug 2024 for the same switch case.
 
     break;
   }
+
+// ml- [TODO] deal with the rest of the expression types  
+#if 0
+  
   
   case ClarityGrammar::ExpressionT::Mapping:
   {
@@ -5181,8 +5052,8 @@ bool clarity_convertert::get_optional_instance(
     // it it looks like that should match the same methodology as for string-xxx types
     if (val_type == "")
     {
-      val_type = ClarityGrammar::get_nested_objtype(ClarityGrammar::get_expression_objtype(ast_node))[0];//ast_node[1]["objtype"][3][0];
-      val_size = ClarityGrammar::get_nested_objtype(ClarityGrammar::get_expression_objtype(ast_node))[2]; //ast_node[1]["objtype"][3][2];
+      val_type = ClarityGrammar::get_nested_objtype(parent_objtype)[0];//ast_node[1]["objtype"][3][0];
+      val_size = ClarityGrammar::get_nested_objtype(parent_objtype)[2]; //ast_node[1]["objtype"][3][2];
     }
 
     const std::string mem_name = key; //it.key();
@@ -5218,7 +5089,7 @@ bool clarity_convertert::get_optional_instance(
       temp_expression_node = ClarityGrammar::get_expression_args(ast_node)[0];
     }
 
-    
+    //because args do not have objtypes but we need objtypes for get_expr to work
     temp_expression_node["objtype"] = objtype;
 
   

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -5338,7 +5338,7 @@ bool clarity_convertert::get_principal_instance(
     temp_expression_node["type"] = "lit_bool";
     temp_expression_node["span"] = ClarityGrammar::get_location_info(expression_value_node);
     //temp_expression_node["identifier"] = mem_name;
-    temp_expression_node["cid"] = ClarityGrammar::get_experession_cid(expression_value_node);
+    temp_expression_node["cid"] = ClarityGrammar::get_expression_cid(expression_value_node);
     temp_expression_node["objtype"] = objtype;
 
     

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -156,8 +156,8 @@ protected:
     const nlohmann::json &ast_node,
     std::string &contract_name);
   bool get_empty_array_ref(const nlohmann::json &ast_node, exprt &new_expr);
-  bool get_tuple_definition(const nlohmann::json &ast_node);
-  bool get_tuple_instance(const nlohmann::json &ast_node, exprt &new_expr);
+  bool get_tuple_definition(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype);
+  bool get_tuple_instance(const nlohmann::json &ast_node,const nlohmann::json &parent_objtype, exprt &new_expr);
   void get_tuple_name(
     const nlohmann::json &ast_node,
     std::string &name,
@@ -322,6 +322,9 @@ protected:
   std::string tgt_func;
   // --contract
   std::string tgt_cnt;
+
+  // --reference of the latest symbol added to the symbol table
+  symbolt *latest_symbol;
 
 private:
   bool get_elementary_type_name_uint(

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -77,7 +77,7 @@ protected:
 
   std::string get_list_struct_id(const nlohmann::json &objtype);
   bool get_list_type(const nlohmann::json &parent_objtype, typet &out);
-  bool get_list_of_entry_type(const nlohmann::json &ast_node, exprt &new_expr);
+  bool get_list_of_entry_type(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype, exprt &new_expr);
 
   // handle the non-contract definition, including struct/enum/error/event/abstract/...
   bool process_c_defined_structs(

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -174,7 +174,7 @@ protected:
   void get_tuple_assignment(code_blockt &_block, const exprt &lop, exprt rop);
   void get_tuple_function_call(code_blockt &_block, const exprt &op);
 
-  bool get_optional_instance(const nlohmann::json &ast_node, exprt &new_expr);
+  bool get_optional_instance(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype, exprt &new_expr);
 
   bool get_principal_instance(const nlohmann::json &ast_node, exprt &new_expr);
   // line number and locations

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -156,6 +156,7 @@ protected:
     const nlohmann::json &ast_node,
     std::string &contract_name);
   bool get_empty_array_ref(const nlohmann::json &ast_node, exprt &new_expr);
+  bool is_nested_tuple(const nlohmann::json &ast_node);
   bool get_tuple_definition(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype);
   bool get_tuple_instance(const nlohmann::json &ast_node,const nlohmann::json &parent_objtype, exprt &new_expr);
   void get_tuple_name(

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -78,7 +78,7 @@ protected:
   std::string get_list_struct_id(const nlohmann::json &objtype);
   bool get_list_type(const nlohmann::json &parent_objtype, typet &out);
   bool get_list_of_entry_type(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype, exprt &new_expr);
-
+  std::string get_list_instance_id(const nlohmann::json &ast_node, std::string name);
   // handle the non-contract definition, including struct/enum/error/event/abstract/...
   bool process_c_defined_structs(
     std::string &id,

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -1205,18 +1205,13 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   {
     return Tuple;
   }
-  // else if (nodeType == "TupleExpression")
-  // {
-  //   return Tuple;
-  // }
-  // else if (nodeType == "Optional")
-  // {
-  //   return Optional;
-  // }
-  // else if (nodeType == "List")
-  // {
-  //   return List;
-  // }
+  else if (nodeType == "list")
+  {
+    return List;
+  }
+  
+
+ 
 
   // else if (nodeType == "Mapping")
   // {

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -1201,6 +1201,10 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   {
     return Optional;
   }
+  else if (nodeType == "tuple_object")
+  {
+    return Tuple;
+  }
   // else if (nodeType == "TupleExpression")
   // {
   //   return Tuple;

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -265,7 +265,7 @@ bool is_literal_type(std::string nodeType)
   if( (nodeType == "standard_principal") || (nodeType == "contract_principal") ||
     (nodeType == "lit_int") || (nodeType == "lit_uint") ||
     (nodeType == "lit_ascii") || (nodeType == "lit_bool") ||
-    (nodeType == "lit_buff") || (nodeType == "lit_utf8"))
+    (nodeType == "lit_buffer") || (nodeType == "lit_utf8"))
   {
     return true;
   }
@@ -571,7 +571,7 @@ bool get_literal_type_from_expr(
           )"_json;
     expression_node = j2;
   }
-  else if (expr_type == "lit_buff")
+  else if (expr_type == "lit_buffer")
   {
     auto j2 = R"(
             ["buffer", "buffer", "4"]              

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -97,7 +97,7 @@ std::string get_expression_lit_value(const nlohmann::json &expression_node)
 {
   std::string expression_type = get_expression_type(expression_node);
 
-  if (ClarityGrammar::is_literal_type(expression_type) || expression_type == "principal")
+  if (ClarityGrammar::is_literal_type(expression_type) || is_principal_declaration(expression_node))
   {
     return expression_node["identifier"].get<std::string>();
   }
@@ -202,18 +202,22 @@ nlohmann::json  get_location_info(const nlohmann::json &expression_node)
 }
 
 // input    : an expression node
-// output   :  the cid of the expression node expression_node["cid"]
-// returns :: false if succesful, or true if failed.
-bool is_standard_principal(const nlohmann::json &expression_node)
+// returns   :  true if expression is a  standard principal declaration node, false otherwise
+bool is_expression_standard_principal(const nlohmann::json &expression_node)
 {
   std::string principal_type = get_expression_type(expression_node);
+  if ((principal_type == "standard_principal") )
+  {
+    return true;
+  }
+
   return false;
 }
 
 
 bool is_literal_type(std::string nodeType)
 {
-  if (
+  if( (nodeType == "standard_principal") || (nodeType == "contract_principal") ||
     (nodeType == "lit_int") || (nodeType == "lit_uint") ||
     (nodeType == "lit_ascii") || (nodeType == "lit_bool") ||
     (nodeType == "lit_buff") || (nodeType == "lit_utf8"))

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -72,7 +72,7 @@ std::string get_expression_type(
 // return   :  the cid of the expression node expression_node["cid"]
 int get_expression_cid(const nlohmann::json &expression_node)
 {
-  return expression_node["cid"].get<int>();
+  return expression_node["cid"].get<int16_t>();
 }
 
 // input    : an expression node

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -36,6 +36,7 @@ nlohmann::json get_expression_body(const nlohmann::json &expression_node);
 nlohmann::json get_expression_return_type(const nlohmann::json &expression_node);
 nlohmann::json get_location_info(const nlohmann::json &expression_node);
 bool is_expression_standard_principal(const nlohmann::json &expression_node);
+std::string get_expression_optional_expr(const nlohmann::json &expression_node);
 
 // end of helper functions
 bool is_literal_type(std::string type);

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -35,7 +35,7 @@ nlohmann::json get_nested_objtype(const nlohmann::json &objtype);
 nlohmann::json get_expression_body(const nlohmann::json &expression_node);
 nlohmann::json get_expression_return_type(const nlohmann::json &expression_node);
 nlohmann::json get_location_info(const nlohmann::json &expression_node);
-bool is_standard_principal(const nlohmann::json &expression_node);
+bool is_expression_standard_principal(const nlohmann::json &expression_node);
 
 // end of helper functions
 bool is_literal_type(std::string type);

--- a/src/clarity-frontend/clarity_template.h
+++ b/src/clarity-frontend/clarity_template.h
@@ -52,10 +52,7 @@ struct principal
 {
     bool contract_is_principal;
     bool contract_is_standard;
-    //char contract_name[128]; //128 bytes long contract name
-    //char issuer_principal_bytes[20];
-    //char version;
-    char issuer_principal_str[149];
+    char issuer_principal_str[222];
   
 };
 

--- a/src/clarity-frontend/clarity_template.h
+++ b/src/clarity-frontend/clarity_template.h
@@ -52,10 +52,10 @@ struct principal
 {
     bool contract_is_principal;
     bool contract_is_standard;
-    char contract_name[128]; //128 bytes long contract name
-    char issuer_principal_bytes[20];
-    char version;
-    char issuer_principal_str[41];
+    //char contract_name[128]; //128 bytes long contract name
+    //char issuer_principal_bytes[20];
+    //char version;
+    char issuer_principal_str[149];
   
 };
 

--- a/src/util/crypto_hash.h
+++ b/src/util/crypto_hash.h
@@ -10,14 +10,14 @@ class crypto_hash
 {
 public:
   std::shared_ptr<crypto_hash_private> p_crypto;
-  unsigned int hash[5];
+  unsigned char hash[20];
 
   bool operator<(const crypto_hash &h2) const;
 
   size_t to_size_t() const
   {
     size_t result = hash[0];
-    for (int i = 1; i < 5; i++)
+    for (int i = 1; i < 20; i++)
       // Do we care about overlaps?
       result ^= hash[i];
     return result;


### PR DESCRIPTION
- Tuples,
- tuples within tuples
- principal within tuples
- Lists
- optionals

Verified to be functional with new AST

Note : 
Addition of "attributes" field in the AST . Search of "parent_identifier" and you'll find comments on what it does.
But generally, the problem is that when we jump into get_expr, we are only working with the "value" node, and have no information of parent containing node. That usually contains the name of the variable.
This isn't required for most cases, but for tuples it was needed. Maybe we can review and it is no longer needed. But for now, it is implemented by passing parent information down using "attributes".

Things that need looking into : 
- There is some padding issue when we encapsulate a struct within a struct along some other members. This is specifically for when we pack tuple within tuples, or any other struct types inside a tuple struct. This needs to be looked into.
- Another thing i have noticed that for "tuple" specifically, the symbol that creates the type is showing the value assigned to it along with it's flag set to L-value, whereas they can only be "type".
- I am going to create two issues to represent these two items so they don't get ignored down the line.


Issues created :
https://github.com/proj-clarity-esbmc/clara_esbmc/issues/14
https://github.com/proj-clarity-esbmc/clara_esbmc/issues/13