### PR TITLE
feat: added functionality for handling multi argument operations

### DIFF
--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -3327,10 +3327,10 @@ bool clarity_convertert::get_expr(
     {
       codet decls("decl-block");
       unsigned ctr = 0;
-      for (auto const &arg_kv : ClarityGrammar::get_expression_args(expr))
+      for (auto const &let_arg : ClarityGrammar::get_expression_args(expr))
       {
         exprt single_decl;
-        if (get_expr(arg_kv, single_decl))
+        if (get_expr(let_arg, single_decl))
           return true;
         decls.operands().push_back(single_decl);
         ++ctr;  
@@ -3342,10 +3342,10 @@ bool clarity_convertert::get_expr(
     // Now handle the body of the let or begin
     unsigned ctr = 0;
     exprt last_expr;
-    for (auto const &stmt_kv : ClarityGrammar::get_expression_body(expr))
+    for (auto const &body_expr : ClarityGrammar::get_expression_body(expr))
     {
       exprt statement;
-      if (get_expr(stmt_kv, statement))
+      if (get_expr(body_expr, statement))
         return true;
 
       // ml- Need to create a temporary result so that all body elements

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -2900,7 +2900,7 @@ bool clarity_convertert::get_expr(
 
   switch (type)
   {
-  case ClarityGrammar::ExpressionT::BinaryOperatorClass:
+  case ClarityGrammar::ExpressionT::MultiOperatorClass:
   {
     nlohmann::json multiop_type_expr;
     if (get_multiple_operator_expr(expr, new_expr))
@@ -2912,7 +2912,7 @@ bool clarity_convertert::get_expr(
     inferred_type = multiop_type_expr;
     break;
   }
-  case ClarityGrammar::ExpressionT::MultiOperatorClass:
+  case ClarityGrammar::ExpressionT::BinaryOperatorClass:
   {
     nlohmann::json binary_type_expr;
     if (get_binary_operator_expr(expr, new_expr))

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -3723,40 +3723,39 @@ bool clarity_convertert::get_multiple_operator_expr(
   nlohmann::json &inferred_type,
   int args_starting_index =  0)
 {
-  // 1. Convert LHS and RHS
-  // For "Assignment" expression, it's called "leftHandSide" or "rightHandSide".
-  // For "BinaryOperation" expression, it's called "leftExpression" or "leftExpression"
   exprt lhs, rhs;
-  // if (expr.contains("leftHandSide"))
-  // {
-  //   nlohmann::json literalType = expr["leftHandSide"]["typeDescriptions"];
-
-  //   if (get_expr(expr["leftHandSide"], lhs))
-  //     return true;
-
-  //   if (get_expr(expr["rightHandSide"], literalType, rhs))
-  //     return true;
-  // }
-  // else if (expr.contains("leftExpression"))
-  // {
-  //   nlohmann::json literalType_l = expr["leftExpression"]["typeDescriptions"];
-  //   nlohmann::json literalType_r = expr["rightExpression"]["typeDescriptions"];
   nlohmann::json type_r;
   nlohmann::json type_l;
-    
   nlohmann::json exp_args = ClarityGrammar::get_expression_args(expr);
+
+    // Convert opcode
+  ClarityGrammar::ExpressionT opcode =
+    ClarityGrammar::get_expr_operator_t(expr);
+  log_debug(
+    "clarity",
+    "	@@@ got multiop.getOpcode: ClarityGrammar::{}",
+    ClarityGrammar::expression_to_str(opcode));
 
   if (1 == exp_args.size())
   {
-    // For some reason Clarity allows single arg bin ops
+    // For some reason Clarity allows single arg ops
     // in which case just return the arg instead of operator
-    if (get_expr(exp_args[0], nullptr, lhs, type_l))
-      return true;
+    // but for is-eq make an exception it always returns true
+    // even if you give it (is-eq false)
+    if (opcode == ClarityGrammar::ExpressionT::BO_EQ)
+    {
+      true_exprt always_true;
+      get_literal_type_from_typet(bool_type(), type_l);
+      lhs = always_true;
+    }
+    else {
+      if (get_expr(exp_args[0], nullptr, lhs, type_l))
+        return true;    
+    }
     
     new_expr = lhs;
     inferred_type = type_l;
     return false;
-
   }
   else if (0 == args_starting_index - 1)
   {
@@ -3802,13 +3801,6 @@ bool clarity_convertert::get_multiple_operator_expr(
       return true;
   }
 
-  // 3. Convert opcode
-  ClarityGrammar::ExpressionT opcode =
-    ClarityGrammar::get_expr_operator_t(expr);
-  log_debug(
-    "clarity",
-    "	@@@ got multiop.getOpcode: ClarityGrammar::{}",
-    ClarityGrammar::expression_to_str(opcode));
 
   switch (opcode)
   {
@@ -4038,7 +4030,24 @@ bool clarity_convertert::get_multiple_operator_expr(
   }
   case ClarityGrammar::ExpressionT::BO_EQ:
   {
-    new_expr = exprt("=", t);
+    new_expr = exprt("=", bool_type());
+    // ml- special handling of equal
+    // Since eq can be of type is-eq(0 1 2)
+    // therefore the rhs must be compared with the first arg
+    // and the new expr should be an and operation
+    // i.e (0 == 1) && (0 == 2)
+    if (0 != args_starting_index - 1)
+    {
+      exprt arg0_lhs;
+      nlohmann::json arg0_type_l;
+      if (get_expr(exp_args[0], nullptr, arg0_lhs, arg0_type_l))
+        return true;
+      
+      exprt anded_rhs = exprt("=", t);
+      anded_rhs.copy_to_operands(arg0_lhs, rhs);
+      rhs = anded_rhs;
+      new_expr = exprt("and", bool_type());
+    }
     break;
   }
   case ClarityGrammar::ExpressionT::BO_LAnd:

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -120,6 +120,7 @@ protected:
     exprt &new_expr,
     nlohmann::json &inferred_type);
   bool get_binary_operator_expr(const nlohmann::json &expr, exprt &new_expr);
+  bool get_multiple_operator_expr(const nlohmann::json &expr, exprt &new_expr, nlohmann::json &inferred_type, int args_starting_index);
   bool get_compound_assign_expr(const nlohmann::json &expr, exprt &new_expr);
   bool get_unary_operator_expr(
     const nlohmann::json &expr,

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -70,6 +70,7 @@ protected:
   // get decl in rule variable-declaration-statement, e.g. function local declaration
   bool get_var_decl_stmt(const nlohmann::json &ast_node, exprt &new_expr);
   bool get_var_decl(const nlohmann::json &ast_node, exprt &new_expr);
+  bool get_let_var_decl(const nlohmann::json &ast_node, exprt &new_expr);
   bool get_function_definition(const nlohmann::json &ast_node);
   void NewFunction(code_typet &type);
   bool get_function_params(const nlohmann::json &pd, exprt &param);

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -121,6 +121,7 @@ protected:
     nlohmann::json &inferred_type);
   bool get_binary_operator_expr(const nlohmann::json &expr, exprt &new_expr);
   bool get_multiple_operator_expr(const nlohmann::json &expr, exprt &new_expr, nlohmann::json &inferred_type, int args_starting_index);
+  bool get_multiple_operator_expr(const nlohmann::json &expr, exprt &new_expr);
   bool get_compound_assign_expr(const nlohmann::json &expr, exprt &new_expr);
   bool get_unary_operator_expr(
     const nlohmann::json &expr,

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -1158,7 +1158,7 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
       return ConditionalOperatorClass;
     }
   }
-  else if (nodeType == "variable_name")
+  else if (nodeType == "variable")
   {
     return DeclRefExprClass;
   }

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -302,6 +302,23 @@ bool operation_is_optional_decl(const nlohmann::json &ast_node)
     return false;
 }
 
+bool operation_is_multiop(const nlohmann::json &ast_node)
+{
+  const std::vector<std::string> multiop_operators{
+    "+",  "-",  "*",   "/",   "and",  "or", "bit-and",  "bit-or",
+    "bit-xor", "is-eq"};
+
+  if (
+    std::find(
+      multiop_operators.begin(),
+      multiop_operators.end(),
+      ast_node["identifier"]) != multiop_operators.end())
+    return true;
+  else
+    return false;
+}
+
+
 bool operation_is_binary(const nlohmann::json &ast_node)
 {
   const std::vector<std::string> binary_operators{
@@ -1136,7 +1153,11 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   // }
   if (nodeType == "native_function")
   {
-    if (operation_is_binary(expr))
+    if (operation_is_multiop(expr))
+    {
+      return MultiOperatorClass;
+    }
+    else if (operation_is_binary(expr))
     {
       return BinaryOperatorClass;
     }
@@ -1299,15 +1320,15 @@ ExpressionT get_expr_operator_t(const nlohmann::json &expr)
   {
     return BO_Shr;
   }
-  else if (expr["identifier"] == "&")
+  else if (expr["identifier"] == "bit-and")
   {
     return BO_And;
   }
-  else if (expr["identifier"] == "^")
+  else if (expr["identifier"] == "bit-xor")
   {
     return BO_Xor;
   }
-  else if (expr["identifier"] == "|")
+  else if (expr["identifier"] == "bit-or")
   {
     return BO_Or;
   }
@@ -1331,15 +1352,15 @@ ExpressionT get_expr_operator_t(const nlohmann::json &expr)
   {
     return BO_NE;
   }
-  else if (expr["identifier"] == "==")
+  else if (expr["identifier"] == "is-eq")
   {
     return BO_EQ;
   }
-  else if (expr["identifier"] == "&&")
+  else if (expr["identifier"] == "and")
   {
     return BO_LAnd;
   }
-  else if (expr["identifier"] == "||")
+  else if (expr["identifier"] == "or")
   {
     return BO_LOr;
   }
@@ -1403,6 +1424,7 @@ const char *expression_to_str(ExpressionT type)
   switch (type)
   {
     ENUM_TO_STR(BinaryOperatorClass)
+    ENUM_TO_STR(MultiOperatorClass)
     ENUM_TO_STR(BO_Assign)
     ENUM_TO_STR(BO_Add)
     ENUM_TO_STR(BO_Sub)

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -1159,6 +1159,14 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   // {
   //   return List;
   // }
+  else if (nodeType == "let")
+  {
+    return LetDeclaration;
+  }
+  else if (nodeType == "let_variable_declaration")
+  {
+    return LetVariableDecl;
+  }  
 
   // else if (nodeType == "Mapping")
   // {

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -319,6 +319,21 @@ bool operation_is_binary(const nlohmann::json &ast_node)
     return false;
 }
 
+bool operation_is_let_begin(const nlohmann::json &ast_node)
+{
+  const std::vector<std::string> let_begin_operators{
+    "let",  "begin"};
+
+  if (
+    std::find(
+      let_begin_operators.begin(),
+      let_begin_operators.end(),
+      ast_node["identifier"]) != let_begin_operators.end())
+    return true;
+  else
+    return false;
+}
+
 bool operation_is_unary(const nlohmann::json &ast_node)
 {
   const std::vector<std::string> unary_operators{"--", "++", "-", "~", "!"};
@@ -1125,6 +1140,10 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
     {
       return BinaryOperatorClass;
     }
+    else if (operation_is_let_begin(expr))
+    {
+      return LetBeginDeclaration;
+    }
     else 
     {
       // ml- if the operation is not binary 
@@ -1159,10 +1178,6 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   // {
   //   return List;
   // }
-  else if (nodeType == "let")
-  {
-    return LetDeclaration;
-  }
   else if (nodeType == "let_variable_declaration")
   {
     return LetVariableDecl;
@@ -1438,6 +1453,8 @@ const char *expression_to_str(ExpressionT type)
     ENUM_TO_STR(Tuple)
     ENUM_TO_STR(Mapping)
     ENUM_TO_STR(CallExprClass)
+    ENUM_TO_STR(LetBeginDeclaration)
+    ENUM_TO_STR(LetVariableDecl)
     ENUM_TO_STR(ImplicitCastExprClass)
     ENUM_TO_STR(IndexAccess)
     ENUM_TO_STR(NewExpression)

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -52,6 +52,7 @@ bool get_operation_type(nlohmann::json &expression_node);
 bool operation_is_conditional(const nlohmann::json &ast_node);
 bool operation_is_unary(const nlohmann::json &ast_node);
 bool operation_is_binary(const nlohmann::json &ast_node);
+bool operation_is_multiop(const nlohmann::json &ast_node);
 bool operation_is_optional_decl(const nlohmann::json &ast_node);
 bool operation_is_let_begin(const nlohmann::json &ast_node);
 nlohmann::json get_optional_type(const nlohmann::json &objtype);
@@ -202,6 +203,7 @@ enum ExpressionT
   // BinaryOperator
   BinaryOperatorClass =
     0, // This type covers all binary operators in Clarity, such as =, +, - .etc
+  MultiOperatorClass, 
   BO_Assign, // =
   BO_Add,    // +
   BO_Sub,    // -

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -53,6 +53,7 @@ bool operation_is_conditional(const nlohmann::json &ast_node);
 bool operation_is_unary(const nlohmann::json &ast_node);
 bool operation_is_binary(const nlohmann::json &ast_node);
 bool operation_is_optional_decl(const nlohmann::json &ast_node);
+bool operation_is_let_begin(const nlohmann::json &ast_node);
 nlohmann::json get_optional_type(const nlohmann::json &objtype);
 std::string get_optional_symbolId(const nlohmann::json &optional_type);
 
@@ -269,8 +270,8 @@ enum ExpressionT
   // FunctionCall
   CallExprClass,
 
-  // LetStatements
-  LetDeclaration,
+  // LetBeginStatements
+  LetBeginDeclaration,
 
   // LetVariable
   LetVariableDecl,

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -269,6 +269,12 @@ enum ExpressionT
   // FunctionCall
   CallExprClass,
 
+  // LetStatements
+  LetDeclaration,
+
+  // LetVariable
+  LetVariableDecl,
+
   // auxiliary type for implicit casting in Clarity, e.g. function return value
   // Clarity does NOT provide such information.
   ImplicitCastExprClass,

--- a/src/util/crypto_hash.cpp
+++ b/src/util/crypto_hash.cpp
@@ -44,5 +44,8 @@ void crypto_hash::ingest(void const *data, unsigned int size)
 
 void crypto_hash::fin()
 {
-  p_crypto->s.get_digest(hash);
+  unsigned int digest[5];
+  assert(sizeof(hash) == sizeof(digest));
+  memcpy(digest, hash, sizeof(digest));
+  p_crypto->s.get_digest(digest);
 }


### PR DESCRIPTION
This change will be able to handle the following scenarios in the manner shown

`(define-read-only (single-more-arg-mul-type (arg int)) 
    (begin 
        (+ (* (/ (- (bit-and (bit-or (bit-xor arg)))))))
        (and (or true))
        (+ arg 1 2)
        (* arg 1 2)
        (/ arg 1 2)
        (- arg 1 2)
        (bit-and arg 1 2)
        (bit-or arg 1 2)
        (bit-xor arg 1 2)
        (and (or true))
        (and true true true)
        (or true false false)
        (is-eq 0)
        (is-eq 0 1)
        (is-eq 0 1 2)
    )
)`

and convert it to the following symbols

`return (
{
tmp_result_0=arg;
tmp_result_1=true;
tmp_result_2=arg + 1 + 2;
tmp_result_3=arg * 1 * 2;
tmp_result_4=(arg / 1) / 2;
tmp_result_5=(arg - 1) - 2;
tmp_result_6=arg & 1 & 2;
tmp_result_7=arg | 1 | 2;
tmp_result_8=arg ^ 1 ^ 2;
tmp_result_9=true;
tmp_result_10=true && true && true;
tmp_result_11=true || false || false;
tmp_result_12=true;
tmp_result_13=0 == 1;
tmp_result_14=0 == 1 && 0 == 2;
});`