### PR TITLE
feat : partial support for define-map and map-insert

### DIFF
--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -1526,6 +1526,7 @@ bool clarity_convertert::get_map_insert_call(const nlohmann::json &ast_expressio
       return false;
 
     }
+    return true;
 }
 bool clarity_convertert::convert_ast_nodes(const nlohmann::json &contract_def)
 {

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -33,6 +33,8 @@ protected:
   bool process_define_constant(nlohmann::json &ast_node);
   bool process_define_map(nlohmann::json &ast_node);
 
+  void set_top_objtype(nlohmann::json &objtype);
+
   std::string get_objtype_type_name(const nlohmann::json &objtype_node);
   std::string get_objtype_type_identifier(const nlohmann::json &objtype_node);
   std::string get_objtype_type_size(const nlohmann::json &objtype_node);
@@ -354,6 +356,9 @@ protected:
 
   // --reference of the latest symbol added to the symbol table
   symbolt *latest_symbol;
+
+  // -- objtype available in the top most s-expression
+  nlohmann::json top_objtype;
 
 private:
   bool get_elementary_type_name_uint(

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -236,6 +236,7 @@ protected:
     // mapping functions 
   bool is_child_mapping(const nlohmann::json &ast_node);
   bool get_mapping_definition(const nlohmann::json &ast_node, exprt &new_expr);
+  bool get_map_insert_call(const nlohmann::json &ast_node, exprt &new_expr);
   bool get_mapping_value_type(const typet &val_type, std::string &_val);
   bool get_mapping_key(const nlohmann::json &ast_node, exprt &new_expr);
   void get_library_function_call(

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -82,6 +82,7 @@ protected:
   symbolt* create_symbol(const nlohmann::json &expr, std::string name, std::string id, typet &t);
   std::string get_struct_symbol_type(const nlohmann::json &expr);
   symbolt* create_struct_symbol(const nlohmann::json &expr, typet &t);
+  bool get_map_type_definition(const nlohmann::json &expr, const nlohmann::json &parent_objtype, exprt &new_expr);
   bool get_response_type_definition(const nlohmann::json &expr, const nlohmann::json &parent_objtype, exprt &new_expr);
   bool get_response_type_instance(const nlohmann::json &expr, const nlohmann::json &parent_objtype, exprt &new_expr);
   std::string get_list_struct_id(const nlohmann::json &objtype);
@@ -103,6 +104,7 @@ protected:
   bool get_error_definition(const nlohmann::json &ast_node);
 
   // handle the implicit constructor
+  bool move_mapping_to_ctor();
   bool add_implicit_constructor();
   bool get_implicit_ctor_ref(exprt &new_expr, const std::string &contract_name);
   bool
@@ -229,7 +231,17 @@ protected:
   nlohmann::json add_dyn_array_size_expr(
     const nlohmann::json &type_descriptor,
     const nlohmann::json &dyn_array_node);
+    // mapping functions 
   bool is_child_mapping(const nlohmann::json &ast_node);
+  bool get_mapping_definition(const nlohmann::json &ast_node, exprt &new_expr);
+  bool get_mapping_value_type(const typet &val_type, std::string &_val);
+  bool get_mapping_key(const nlohmann::json &ast_node, exprt &new_expr);
+  void get_library_function_call(
+  const std::string &func_name,
+  const std::string &func_id,
+  const typet &t,
+  const locationt &l,
+  exprt &new_expr);
 
   void get_default_symbol(
     symbolt &symbol,
@@ -330,6 +342,10 @@ protected:
   // dealing with the implicit constructor call
   // this is to avoid reference to stack memory associated with local variable returned
   const nlohmann::json empty_json;
+
+  // this block stores the map_init function calls and
+  // will merge to the constructor later on
+  code_blockt map_init_block;
 
   // --function
   std::string tgt_func;

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -384,7 +384,7 @@ bool operation_is_binary(const nlohmann::json &ast_node)
   const std::vector<std::string> binary_operators{
     "+",  "-",  "*",   "/",   "%",  "<<", ">>", "&",  "|",  ">",
     "<",  ">=", "<=",  "!=",  "==", "&&", "||", "+=", "-=", "*=",
-    "/=", "%=", "<<=", ">>=", "&=", "|=", "^=", "**", "map-insert"};
+    "/=", "%=", "<<=", ">>=", "&=", "|=", "^=", "**"};
 
   if (
     std::find(
@@ -1380,7 +1380,7 @@ ExpressionT get_unary_expr_operator_t(const nlohmann::json &expr, bool uo_pre)
 
 ExpressionT get_expr_operator_t(const nlohmann::json &expr)
 {
-  if ((expr["identifier"] == "=") || (expr["identifier"] == "map-insert"))
+  if (expr["identifier"] == "=")
   {
     return BO_Assign;
   }

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -384,7 +384,7 @@ bool operation_is_binary(const nlohmann::json &ast_node)
   const std::vector<std::string> binary_operators{
     "+",  "-",  "*",   "/",   "%",  "<<", ">>", "&",  "|",  ">",
     "<",  ">=", "<=",  "!=",  "==", "&&", "||", "+=", "-=", "*=",
-    "/=", "%=", "<<=", ">>=", "&=", "|=", "^=", "**"};
+    "/=", "%=", "<<=", ">>=", "&=", "|=", "^=", "**", "map-insert"};
 
   if (
     std::find(
@@ -745,6 +745,10 @@ ContractBodyElementT get_contract_body_element_t(const nlohmann::json &element)
   else if (element_type == "function_declaration")
   {
     return FunctionDef;
+  }
+  else if (element_type == "native_function")
+  {
+    return TopLevelNativeFunction;
   }
   else
   {
@@ -1376,7 +1380,7 @@ ExpressionT get_unary_expr_operator_t(const nlohmann::json &expr, bool uo_pre)
 
 ExpressionT get_expr_operator_t(const nlohmann::json &expr)
 {
-  if (expr["identifier"] == "=")
+  if ((expr["identifier"] == "=") || (expr["identifier"] == "map-insert"))
   {
     return BO_Assign;
   }

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -735,7 +735,10 @@ ContractBodyElementT get_contract_body_element_t(const nlohmann::json &element)
   std::string element_type = get_expression_type(element);
   if (
     (element_type == "variable_declaration") ||
-    (element_type == "constant_declaration"))
+    (element_type == "constant_declaration") ||
+    (element_type == "map_declaration")
+    )
+
   {
     return VarDecl;
   }
@@ -791,20 +794,21 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
     {
       return TupleTypeName;
     }
-    if (typeIdentifier.compare(0, 10, "t_mapping(") == 0)
-    {
-      return MappingTypeName;
-    }
+  
     else if (typeString == "buffer")
     {
       //buff in clarity can be considered as array of bytes
 
       return BuffTypeName;
     }
-    if (typeString == "response")
+    else if (typeString == "response")
     {
 
       return ResponseTypeName;
+    }
+    else if (typeString == "map")
+    {
+      return MapTypeName;
     }
     else if (typeString == "list")
     {
@@ -880,7 +884,7 @@ const char *type_name_to_str(TypeNameT type)
     ENUM_TO_STR(ContractTypeName)
     ENUM_TO_STR(OptionalTypeName)
     ENUM_TO_STR(TupleTypeName)
-    ENUM_TO_STR(MappingTypeName)
+    ENUM_TO_STR(MapTypeName)
     ENUM_TO_STR(BuiltinTypeName)
     ENUM_TO_STR(ReturnTypeName)
     ENUM_TO_STR(TypeNameTError)
@@ -1279,6 +1283,10 @@ ExpressionT get_expression_t(const nlohmann::json &expr)
   else if (nodeType == "list")
   {
     return List;
+  }
+  else if (nodeType == "map_declaration")
+  {
+    return Mapping;
   }
   
 

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -14,7 +14,9 @@ enum ContractBodyElementT
 {
   VarDecl = 0, // rule variable-declaration
   FunctionDef, // rule function-definition
-  ContractBodyElementTError
+  TopLevelNativeFunction, //native functions used at global state (map-insert)
+  ContractBodyElementTError,
+
 };
 ContractBodyElementT get_contract_body_element_t(const nlohmann::json &element);
 const char *contract_body_element_to_str(ContractBodyElementT type);

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -85,9 +85,6 @@ enum TypeNameT
   // tuple
   TupleTypeName,
 
-  // mapping
-  MappingTypeName,
-
   // built-in member
   BuiltinTypeName,
 
@@ -96,6 +93,9 @@ enum TypeNameT
 
   // clarity response Type
   ResponseTypeName,
+
+  // define-map
+  MapTypeName,
 
   TypeNameTError
 };

--- a/src/clarity-frontend/clarity_template.h
+++ b/src/clarity-frontend/clarity_template.h
@@ -19,7 +19,6 @@ const std::string clar_header = R"(
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <stdio.h>
 // #include <stdbool.h>
 
 )";
@@ -426,10 +425,7 @@ void map_set_int(map_int_t *m, const char *key, const int value)
 void map_set_uint(map_uint_t *m, const char *key, const unsigned int value)
 {
 	(m)->tmp = value;
-	int len = strlen(key);
 	map_set_(&(m)->base, key, &(m)->tmp, sizeof((m)->tmp));
-	
-	unsigned int *ret = map_get_uint(m, key);
 }
 void map_set_string(map_string_t *m, const char *key, char *value)
 {

--- a/src/clarity-frontend/clarity_template.h
+++ b/src/clarity-frontend/clarity_template.h
@@ -19,6 +19,7 @@ const std::string clar_header = R"(
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 // #include <stdbool.h>
 
 )";
@@ -67,13 +68,14 @@ struct principal
 const std::string clar_preprocessed = R"(
 
 ///<<< this is where you should put code >>>
-
-///<<< this marks the end of preprocessed types >>>
-typedef struct map_square_map map_square_map;
+//typedef      struct ft_fungible_token ft_fungible_token;
+typedef      struct map_square_map square_map;
 
      struct map_square_map{
                signed char * square;
 };
+///<<< this marks the end of preprocessed types >>>
+
 
 )";
 
@@ -365,15 +367,34 @@ typedef struct map_bool_t
 // end older more generic implementation
 
 // custom types maps
-map_t(map_square_map)
+// every new map type will have the following :
+// 1 - definition e-g map_t(tuple struct name)
+// 2 - map_init definition
+// 3 - map_set definition
+// 4 - map_get definition
 
-
+///<<< add maps related preprocessed code here >>>
+// preprocessed code for map square_map 
+map_t(square_map)
+void map_init_square_map(square_map_t *m) 
+                     { 
+                         memset(m, 0, sizeof(*(m))); 
+                     }
+void map_set_square_map(square_map_t *m, const char *key, const square_map value) 
+                     { 
+                         (m)->tmp = value; 
+                         map_set_(&(m)->base, key, &(m)->tmp, sizeof((m)->tmp)); 
+                     }
+square_map *map_get_square_map(square_map_t *m, const char *key) 
+                     { 
+                         (m)->ref = map_get_(&(m)->base, key); 
+                         zero_int = 0; 
+                         return (m)->ref != NULL ? (m)->ref : &zero_int; 
+                     }
+///<<< this marks the end of preprocessed maps code >>>
 // end custom types maps
-void map_init_map_square_map(map_square_map *m)
-{
-	memset(m, 0, sizeof(*(m)));
-}
 
+unsigned int *map_get_uint(map_uint_t *m, const char *key);
 
 /// Init
 void map_init_int(map_int_t *m)
@@ -405,7 +426,10 @@ void map_set_int(map_int_t *m, const char *key, const int value)
 void map_set_uint(map_uint_t *m, const char *key, const unsigned int value)
 {
 	(m)->tmp = value;
+	int len = strlen(key);
 	map_set_(&(m)->base, key, &(m)->tmp, sizeof((m)->tmp));
+	
+	unsigned int *ret = map_get_uint(m, key);
 }
 void map_set_string(map_string_t *m, const char *key, char *value)
 {


### PR DESCRIPTION
You will have to use --unwind 3 flag with the esbmc to make use of maps. otherwise it will run into a VERY long loop unrolling process.

this branch also introduces `top_objtype` variable that contains the topmost objtype in the node. Can be referenced anywhere in the code as and when needed.

It also introcues capability to add code to constructor.
- look for `map_init_block` and `move_mapping_to_ctor`

Also introduces `TopLevelNativeFunction` as contract body element.

Further suggesting to add the following command line params to our esbmc calls :
`--force-malloc-success --unwind 2 --no-unwinding-assertions`
