### PR TITLE
feat: handles response data type and response as function return type

### DIFF
--- a/apple_silicon_setup.sh
+++ b/apple_silicon_setup.sh
@@ -103,10 +103,10 @@ command -v make > /dev/null || error_exit "Make not found. Please ensure it is i
 # Step 11: Configure ESBMC build using CMake
 if xcodebuild -version &> /dev/null; then
   echo "Xcode is installed. Using the Xcode SDK for building ESBMC."
-  cmake .. -DENABLE_Z3=1 -DENABLE_SOLIDITY_FRONTEND=On -DENABLE_CLARITY_FRONTEND=On -DCMAKE_BUILD_TYPE=Debug -DC2GOTO_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk || error_exit "CMake configuration failed."
+  cmake .. -DENABLE_Z3=1 -DENABLE_CLARITY_FRONTEND=On -DCMAKE_BUILD_TYPE=Debug -DC2GOTO_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk || error_exit "CMake configuration failed."
 else
   echo "Using Command Line Tools SDK for building ESBMC."
-  cmake .. -DENABLE_Z3=1 -DENABLE_SOLIDITY_FRONTEND=On -DENABLE_CLARITY_FRONTEND=On -DCMAKE_BUILD_TYPE=Debug -DC2GOTO_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk || error_exit "CMake configuration failed."
+  cmake .. -DENABLE_Z3=1 -DENABLE_CLARITY_FRONTEND=On -DCMAKE_BUILD_TYPE=Debug -DC2GOTO_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk || error_exit "CMake configuration failed."
 fi
 
 # Step 12: Build ESBMC

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -2342,6 +2342,14 @@ bool clarity_convertert::get_function_definition(const nlohmann::json &ast_node)
         type.return_type())))
     return true;
 
+  // [TODO] will deel with tuples and optionals later
+  // Add the functions return response type to the symbol table
+  if (type.return_type().get("#clar_type") == "response")
+  {
+    // Add this response type to symbols
+    add_response_symbol_table(expression_node, type.return_type());
+  }
+
 // special handling for return_type:
 #if 0
   // [TODO] will deel with return types later as these are complex
@@ -2424,6 +2432,8 @@ bool clarity_convertert::get_function_definition(const nlohmann::json &ast_node)
 
   NewFunction(type);
 
+  added_symbol.type = type;
+
   // 12. Convert body and embed the body into the same symbol
   if (expression_node.contains("body"))
   {
@@ -2436,13 +2446,7 @@ bool clarity_convertert::get_function_definition(const nlohmann::json &ast_node)
       return true;
 
     added_symbol.value = body_exprt;
-
-    const irep_idt tag = body_exprt.return_type().tag();
-    if (tag.as_string().length())
-      type.return_type().tag(tag);
   }
-  added_symbol.type = type;
-
   //assert(!"done - finished all expr stmt in function?");
 
   // 13. Restore current_functionDecl

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -2347,7 +2347,7 @@ bool clarity_convertert::get_function_definition(const nlohmann::json &ast_node)
   if (type.return_type().get("#clar_type") == "response")
   {
     // Add this response type to symbols
-    add_response_symbol_table(expression_node, type.return_type());
+    create_response_symbol(expression_node, type.return_type());
   }
 
 // special handling for return_type:
@@ -4053,9 +4053,8 @@ bool clarity_convertert::get_expr(
  * @param t The type to be updated as a struct type.
  * @return The created response symbol for the struct.
  */
-symbolt *clarity_convertert::add_response_symbol_table(
-  const nlohmann::json &expr,
-  typet &t)
+symbolt *
+clarity_convertert::create_response_symbol(const nlohmann::json &expr, typet &t)
 {
   std::string struct_name =
     "response_" + std::to_string(ClarityGrammar::get_expression_cid(expr));
@@ -4160,7 +4159,7 @@ bool clarity_convertert::get_response_operator_expr(
   exprt second_val = gen_zero(second_comp_type);
 
   // add the response symbol
-  symbolt *struct_sym = add_response_symbol_table(expr, response_type);
+  symbolt *struct_sym = create_response_symbol(expr, response_type);
 
   // push the values
   exprt response_object = struct_exprt(response_type);

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -3647,13 +3647,9 @@ bool clarity_convertert::get_expr(
   }
   case ClarityGrammar::ExpressionT::Response:
   {
-    // build component
-    // expr , new_expr, literal_type (parent_objtype)
-    get_response_type_definition(expr, literal_type, new_expr);
-
-    // assign values to the component
-    get_response_type_instance(expr, literal_type, new_expr);
-
+    // build component from response
+    // NOTE: @dev -- literal_type shouldn't be null
+    get_response_operator_expr(literal_type, expr, new_expr);
     break;
   }
 
@@ -4037,6 +4033,135 @@ bool clarity_convertert::get_expr(
   }
 
   new_expr.location() = location;
+  return false;
+}
+
+/**
+ * @brief Creates a response struct symbol based on the given JSON expression and updates the provided type.
+ *
+ * This function is different from create_struct_symbol in that it uses a 
+ * simplistic struct name and id using the expression nodes cid
+ *
+ * @param expr The JSON expression representing the struct.
+ * @param t The type to be updated as a struct type.
+ * @return The created response symbol for the struct.
+ */
+symbolt *clarity_convertert::add_response_symbol_table(
+  const nlohmann::json &expr,
+  typet &t)
+{
+  std::string struct_name =
+    "response_" + std::to_string(ClarityGrammar::get_expression_cid(expr));
+  std::string struct_id =
+    prefix + "struct " + struct_name; //get_struct_symbol_id(expr, struct_name);
+  t.tag("struct " + struct_name);
+  symbolt *s = create_symbol(expr, struct_name, struct_id, t);
+  s->is_type = true;
+  return s;
+}
+
+/// @brief Creates a response struct type, from a response expression
+/// and on the fly adds the response struct type to the symbol table
+/// and then creates the instance of it and assigns the instance the
+/// values
+/// @param expr             : expression node
+/// @param new_expr         : output expression
+/// @return False if success, True otherwise
+bool clarity_convertert::get_response_operator_expr(
+  const nlohmann::json &literal_type,
+  const nlohmann::json &expr,
+  exprt &new_expr)
+{
+  nlohmann::json args;
+  nlohmann::json response_data;
+  nlohmann::json response_err_ok_identifier;
+
+  // ml- for conditional operation the args[0] contains the
+  //     conditions expression
+  args = ClarityGrammar::get_expression_args(expr);
+  response_err_ok_identifier = ClarityGrammar::get_expression_identifier(expr);
+  // check that there should be exact 1 element in args
+  if (args.is_array() && args.size() == 1)
+  {
+    response_data = args[0];
+  }
+  else
+  {
+    log_debug(
+      "clarity",
+      "	@@@ get_response_operator_expr args are not array or does not have one "
+      "arguments {}",
+      args.dump());
+    return true;
+  }
+
+  // Extracts the response data
+  exprt response;
+  if (get_expr(response_data, response))
+    return true;
+
+  // For the symbol table add the cid to the params if searching
+  // is needed
+  typet response_type = struct_typet();
+  response_type.set("#cpp_type", "void");
+  response_type.set("#clar_type", "response");
+  response_type.set(
+    "#clar_response_id",
+    std::to_string(ClarityGrammar::get_expression_cid(expr)));
+
+  // setup the is_ok flag in type
+  typet response_flag_type = bool_typet();
+  response_flag_type.set("#cpp_type", "bool");
+  std::string name = "is_ok";
+  struct_typet::componentt comp_is_ok(name, name, response_flag_type);
+  to_struct_type(response_type).components().push_back(comp_is_ok);
+
+  // Set the is_ok flag based on the response data
+  exprt is_ok;
+  typet response_data_type = response.type();
+
+  // setup the ok and error value
+  std::string second_comp_name = "err_val";
+  typet second_comp_type;
+  nlohmann::json nested_objtype =
+    ClarityGrammar::get_nested_objtype(literal_type);
+
+  if (response_err_ok_identifier == "ok")
+  {
+    name = "ok_val";
+    is_ok = true_exprt();
+    // get the type of second component from leteral type
+    get_type_description(nested_objtype[1], second_comp_type);
+  }
+  else if (response_err_ok_identifier == "err")
+  {
+    name = "err_val";
+    second_comp_name = "ok_val";
+    is_ok = false_exprt();
+    // get the type of second component from leteral type
+    get_type_description(nested_objtype[0], second_comp_type);
+  }
+  // Add the response data type to the type and add it to the
+  // symbol table
+  struct_typet::componentt response_ok_err_vall(name, name, response_data_type);
+  to_struct_type(response_type).components().push_back(response_ok_err_vall);
+
+  // Add the second component to the type and init with zero
+  struct_typet::componentt second_comp_response(
+    second_comp_name, second_comp_name, second_comp_type);
+  to_struct_type(response_type).components().push_back(second_comp_response);
+  exprt second_val = gen_zero(second_comp_type);
+
+  // add the response symbol
+  symbolt *struct_sym = add_response_symbol_table(expr, response_type);
+
+  // push the values
+  exprt response_object = struct_exprt(response_type);
+  response_object.copy_to_operands(is_ok);
+  response_object.copy_to_operands(response);
+  response_object.copy_to_operands(second_val);
+  new_expr = response_object;
+
   return false;
 }
 
@@ -5248,6 +5373,32 @@ bool clarity_convertert::get_type_description(
     new_type = struct_typet();
     new_type.set("#cpp_type", "void");
     new_type.set("#clar_type", "response");
+
+    typet response_flag_type = bool_typet();
+    response_flag_type.set("#cpp_type", "bool");
+    std::string name = "is_ok";
+    struct_typet::componentt comp_is_ok(name, name, response_flag_type);
+    to_struct_type(new_type).components().push_back(comp_is_ok);
+
+    nlohmann::json response_ok_err_objtypes =
+      ClarityGrammar::get_nested_objtype(type_name);
+
+    // get the type of the ok
+    typet response_ok_type;
+    if (get_type_description(response_ok_err_objtypes[0], response_ok_type))
+      return true;
+
+    name = "ok_val";
+    struct_typet::componentt response_ok_val(name, name, response_ok_type);
+    to_struct_type(new_type).components().push_back(response_ok_val);
+
+    typet response_err_type;
+    if (get_type_description(response_ok_err_objtypes[1], response_err_type))
+      return true;
+
+    name = "err_val";
+    struct_typet::componentt response_err_val(name, name, response_err_type);
+    to_struct_type(new_type).components().push_back(response_err_val);
 
     break;
   }

--- a/src/clarity-frontend/clarity_convert.cpp
+++ b/src/clarity-frontend/clarity_convert.cpp
@@ -2388,7 +2388,7 @@ bool clarity_convertert::get_function_definition(const nlohmann::json &ast_node)
   symbolt symbol;
   get_default_symbol(symbol, debug_modulename, type, name, id, location_begin);
 
-  symbol.lvalue = true;
+  symbol.lvalue = false;
   symbol.is_extern =
     false; // TODO: hard coded for now, may need to change later
   symbol.file_local = false;

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -90,7 +90,7 @@ protected:
     typet &t);
   std::string get_struct_symbol_type(const nlohmann::json &expr);
   symbolt *create_struct_symbol(const nlohmann::json &expr, typet &t);
-  symbolt *add_response_symbol_table(const nlohmann::json &expr, typet &t);
+  symbolt *create_response_symbol(const nlohmann::json &expr, typet &t);
   bool get_map_type_definition(
     const nlohmann::json &expr,
     const nlohmann::json &parent_objtype,

--- a/src/clarity-frontend/clarity_convert.h
+++ b/src/clarity-frontend/clarity_convert.h
@@ -63,7 +63,8 @@ protected:
   bool define_principal_struct();
   bool define_optional_type(std::string optional_type);
   bool annotate_ast_node(nlohmann::json &expr);
-  std::string get_response_symbolId(const nlohmann::json &expr , std::string &name);
+  std::string
+  get_response_symbolId(const nlohmann::json &expr, std::string &name);
   // end-m-ali
 
   bool convert_ast_nodes(const nlohmann::json &contract_def);
@@ -79,18 +80,41 @@ protected:
   void NewFunction(code_typet &type);
   bool get_function_params(const nlohmann::json &pd, exprt &param);
   bool get_default_function(const std::string name, const std::string id);
-  
-  std::string get_struct_symbol_id(const nlohmann::json &expr, std::string &name);
-  symbolt* create_symbol(const nlohmann::json &expr, std::string name, std::string id, typet &t);
+
+  std::string
+  get_struct_symbol_id(const nlohmann::json &expr, std::string &name);
+  symbolt *create_symbol(
+    const nlohmann::json &expr,
+    std::string name,
+    std::string id,
+    typet &t);
   std::string get_struct_symbol_type(const nlohmann::json &expr);
-  symbolt* create_struct_symbol(const nlohmann::json &expr, typet &t);
-  bool get_map_type_definition(const nlohmann::json &expr, const nlohmann::json &parent_objtype, exprt &new_expr);
-  bool get_response_type_definition(const nlohmann::json &expr, const nlohmann::json &parent_objtype, exprt &new_expr);
-  bool get_response_type_instance(const nlohmann::json &expr, const nlohmann::json &parent_objtype, exprt &new_expr);
+  symbolt *create_struct_symbol(const nlohmann::json &expr, typet &t);
+  symbolt *add_response_symbol_table(const nlohmann::json &expr, typet &t);
+  bool get_map_type_definition(
+    const nlohmann::json &expr,
+    const nlohmann::json &parent_objtype,
+    exprt &new_expr);
+  bool get_response_type_definition(
+    const nlohmann::json &expr,
+    const nlohmann::json &parent_objtype,
+    exprt &new_expr);
+  bool get_response_type_instance(
+    const nlohmann::json &expr,
+    const nlohmann::json &parent_objtype,
+    exprt &new_expr);
+  bool get_response_operator_expr(
+    const nlohmann::json &literal_type,
+    const nlohmann::json &expr,
+    exprt &new_expr);
   std::string get_list_struct_id(const nlohmann::json &objtype);
   bool get_list_type(const nlohmann::json &parent_objtype, typet &out);
-  bool get_list_of_entry_type(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype, exprt &new_expr);
-  std::string get_list_instance_id(const nlohmann::json &ast_node, std::string name);
+  bool get_list_of_entry_type(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &parent_objtype,
+    exprt &new_expr);
+  std::string
+  get_list_instance_id(const nlohmann::json &ast_node, std::string name);
   // handle the non-contract definition, including struct/enum/error/event/abstract/...
   bool process_c_defined_structs(
     std::string &id,
@@ -132,7 +156,11 @@ protected:
     exprt &new_expr,
     nlohmann::json &inferred_type);
   bool get_binary_operator_expr(const nlohmann::json &expr, exprt &new_expr);
-  bool get_multiple_operator_expr(const nlohmann::json &expr, exprt &new_expr, nlohmann::json &inferred_type, int args_starting_index);
+  bool get_multiple_operator_expr(
+    const nlohmann::json &expr,
+    exprt &new_expr,
+    nlohmann::json &inferred_type,
+    int args_starting_index);
   bool get_multiple_operator_expr(const nlohmann::json &expr, exprt &new_expr);
   bool get_compound_assign_expr(const nlohmann::json &expr, exprt &new_expr);
   bool get_unary_operator_expr(
@@ -173,8 +201,14 @@ protected:
   bool get_empty_array_ref(const nlohmann::json &ast_node, exprt &new_expr);
   bool is_nested_response(const nlohmann::json &ast_node);
   bool is_nested_tuple(const nlohmann::json &ast_node);
-  bool get_tuple_definition(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype, exprt &new_expr);
-  bool get_tuple_instance(const nlohmann::json &ast_node,const nlohmann::json &parent_objtype, exprt &new_expr);
+  bool get_tuple_definition(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &parent_objtype,
+    exprt &new_expr);
+  bool get_tuple_instance(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &parent_objtype,
+    exprt &new_expr);
   void get_tuple_name(
     const nlohmann::json &ast_node,
     std::string &name,
@@ -191,7 +225,10 @@ protected:
   void get_tuple_assignment(code_blockt &_block, const exprt &lop, exprt rop);
   void get_tuple_function_call(code_blockt &_block, const exprt &op);
 
-  bool get_optional_instance(const nlohmann::json &ast_node, const nlohmann::json &parent_objtype, exprt &new_expr);
+  bool get_optional_instance(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &parent_objtype,
+    exprt &new_expr);
 
   bool get_principal_instance(const nlohmann::json &ast_node, exprt &new_expr);
   // line number and locations
@@ -233,18 +270,18 @@ protected:
   nlohmann::json add_dyn_array_size_expr(
     const nlohmann::json &type_descriptor,
     const nlohmann::json &dyn_array_node);
-    // mapping functions 
+  // mapping functions
   bool is_child_mapping(const nlohmann::json &ast_node);
   bool get_mapping_definition(const nlohmann::json &ast_node, exprt &new_expr);
   bool get_map_insert_call(const nlohmann::json &ast_node, exprt &new_expr);
   bool get_mapping_value_type(const typet &val_type, std::string &_val);
   bool get_mapping_key(const nlohmann::json &ast_node, exprt &new_expr);
   void get_library_function_call(
-  const std::string &func_name,
-  const std::string &func_id,
-  const typet &t,
-  const locationt &l,
-  exprt &new_expr);
+    const std::string &func_name,
+    const std::string &func_id,
+    const typet &t,
+    const locationt &l,
+    exprt &new_expr);
 
   void get_default_symbol(
     symbolt &symbol,
@@ -256,7 +293,10 @@ protected:
 
   std::string get_ctor_call_id(const std::string &contract_name);
   bool get_clar_builtin_ref(const nlohmann::json expr, exprt &new_expr);
-  bool get_clar_builtin_ref(const nlohmann::json expr, exprt &new_expr, const nlohmann::json &expr_type);
+  bool get_clar_builtin_ref(
+    const nlohmann::json expr,
+    exprt &new_expr,
+    const nlohmann::json &expr_type);
   // literal conversion functions
   bool convert_integer_literal(
     const nlohmann::json &integer_literal,
@@ -281,7 +321,10 @@ protected:
     const nlohmann::json &bool_literal,
     std::string the_value,
     exprt &dest);
-  bool convert_string_literal(const nlohmann::json &string_literal_type, std::string the_value, exprt &dest);
+  bool convert_string_literal(
+    const nlohmann::json &string_literal_type,
+    std::string the_value,
+    exprt &dest);
   void convert_type_expr(const namespacet &ns, exprt &dest, const typet &type);
   bool
   convert_hex_literal(std::string the_value, exprt &dest, const int n = 128);

--- a/src/clarity-frontend/clarity_grammar.cpp
+++ b/src/clarity-frontend/clarity_grammar.cpp
@@ -853,7 +853,7 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
       uint_string_to_type_map.count(typeString) ||
       int_string_to_type_map.count(typeString) || typeString == "bool" ||
       typeString == "string-ascii" || typeString == "string-utf8" ||
-      typeString == "principal")
+      typeString == "principal" || typeString == "none")
     {
       // For state var declaration,
       return ElementaryTypeName;
@@ -949,6 +949,10 @@ ElementaryTypeNameT get_elementary_type_name_t(const nlohmann::json &type_name)
   if (typeString == "bool")
   {
     return BOOL;
+  }
+  if (typeString == "none")
+  {
+    return NONE;
   }
   if (typeString.find("uint_const") != std::string::npos)
   {

--- a/src/clarity-frontend/clarity_grammar.h
+++ b/src/clarity-frontend/clarity_grammar.h
@@ -12,8 +12,8 @@ namespace ClarityGrammar
 // rule contract-body-element
 enum ContractBodyElementT
 {
-  VarDecl = 0, // rule variable-declaration
-  FunctionDef, // rule function-definition
+  VarDecl = 0,            // rule variable-declaration
+  FunctionDef,            // rule function-definition
   TopLevelNativeFunction, //native functions used at global state (map-insert)
   ContractBodyElementTError,
 
@@ -35,7 +35,8 @@ nlohmann::json get_expression_args(const nlohmann::json &expression_node);
 nlohmann::json get_expression_objtype(const nlohmann::json &expression_node);
 nlohmann::json get_nested_objtype(const nlohmann::json &objtype);
 nlohmann::json get_expression_body(const nlohmann::json &expression_node);
-nlohmann::json get_expression_return_type(const nlohmann::json &expression_node);
+nlohmann::json
+get_expression_return_type(const nlohmann::json &expression_node);
 nlohmann::json get_location_info(const nlohmann::json &expression_node);
 bool is_expression_standard_principal(const nlohmann::json &expression_node);
 std::string get_expression_optional_expr(const nlohmann::json &expression_node);
@@ -62,7 +63,7 @@ bool operation_is_let_begin(const nlohmann::json &ast_node);
 nlohmann::json get_optional_type(const nlohmann::json &objtype);
 std::string get_optional_symbolId(const nlohmann::json &optional_type);
 std::string get_clarity_mapped_types(const nlohmann::json &objtype);
-std::string get_struct_symbolId (const nlohmann::json &objtype);
+std::string get_struct_symbolId(const nlohmann::json &objtype);
 /* end m-ali*/
 
 // rule type-name
@@ -116,6 +117,7 @@ enum ElementaryTypeNameT
 
   // rule bool
   BOOL,
+  NONE,
 
   // rule address
   PRINCIPAL,
@@ -211,7 +213,7 @@ enum ExpressionT
   // BinaryOperator
   BinaryOperatorClass =
     0, // This type covers all binary operators in Clarity, such as =, +, - .etc
-  MultiOperatorClass, 
+  MultiOperatorClass,
   BO_Assign, // =
   BO_Add,    // +
   BO_Sub,    // -

--- a/src/clarity-frontend/typecast.cpp
+++ b/src/clarity-frontend/typecast.cpp
@@ -1,6 +1,8 @@
 #include <clarity-frontend/typecast.h>
 #include <util/c_typecast.h>
 #include <util/c_types.h>
+#include <util/message.h>
+#include <util/expr_util.h>
 #include <util/simplify_expr_class.h>
 #include <stdexcept>
 #include <sstream>
@@ -9,4 +11,106 @@ void clarity_gen_typecast(const namespacet &ns, exprt &dest, const typet &type)
 {
   c_typecastt c_typecast(ns);
   c_typecast.implicit_typecast(dest, type);
+}
+/**
+ * add missing ok / err value to struct
+ * set type as destination type and init with zero value
+ */
+void clarity_typecast_response(
+  contextt &context,
+  exprt &source_val,
+  const typet &dest_type)
+{
+  typet source_type;
+  if (
+    source_val.type().id() == typet::id_struct &&
+    source_val.type().get("#clar_type") == "response")
+  {
+    source_type = source_val.type();
+  }
+  else if (
+    source_val.type().id() == typet::id_code &&
+    to_code_type(source_val.type()).return_type().get("#clar_type") ==
+      "response")
+  {
+    source_type = to_code_type(source_val.type()).return_type();
+  }
+  else
+  {
+    return;
+  }
+
+  if (!source_type.is_empty())
+  {
+    // / List of required components
+    std::vector<std::string> required_components = {
+      "is_ok", "ok_val", "err_val"};
+
+    // Create a set to store the names of components in type & value
+    std::set<std::string> type_components;
+    std::set<std::string> value_components;
+
+    // verify destination type is response struct type
+    const struct_typet &dest_struct_type = to_struct_type(dest_type);
+    for (const auto &comp : dest_struct_type.components())
+    {
+      std::string component_name = id2string(comp.get_name());
+      type_components.insert(component_name);
+    }
+
+    for (const std::string &required_comp : required_components)
+    {
+      if (type_components.find(required_comp) == type_components.end())
+      {
+        log_error(
+          "Error: Invalid response type. Missing '{}' component. Aborting...",
+          std::string(required_comp));
+        abort();
+      }
+    }
+
+    // Iterate over the components and collect their names
+    for (const auto &comp : to_struct_type(source_type).components())
+    {
+      std::string component_name = id2string(comp.get_name());
+      value_components.insert(component_name);
+    }
+
+    for (const std::string &required_comp : required_components)
+    {
+      if (value_components.find(required_comp) == value_components.end())
+      {
+        if (required_comp == "is_ok")
+        {
+          log_error(
+            "Error: 'is_ok' component is missing from source_val. aborting...");
+          abort();
+        }
+        else if (required_comp == "ok_val" || required_comp == "err_val")
+        {
+          const struct_union_typet::componentt &missing_comp =
+            dest_struct_type.get_component(required_comp);
+          const exprt missing_val = gen_zero(missing_comp.type());
+          // push missing type & value to source
+          to_struct_type(source_val.type())
+            .components()
+            .push_back(missing_comp);
+          source_val.copy_to_operands(missing_val);
+
+          // the added struct symbol also won't have this component.
+          // get the struct symbol name
+          const std::string name =
+            "tag-struct response_" +
+            source_val.type().get("#clar_response_id").as_string();
+          symbolt *type_symbol = context.find_symbol(name);
+          if (type_symbol != nullptr)
+          {
+            to_struct_type(type_symbol->type)
+              .components()
+              .push_back(missing_comp);
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/clarity-frontend/typecast.h
+++ b/src/clarity-frontend/typecast.h
@@ -6,5 +6,9 @@
 
 extern void
 clarity_gen_typecast(const namespacet &ns, exprt &dest, const typet &type);
+extern void clarity_typecast_response(
+  contextt &context,
+  exprt &source_val,
+  const typet &dest_type);
 
 #endif /* CLARITY_TYPECAST_H_ */


### PR DESCRIPTION
* defines the symbol for response variable
* sets init value for response variable
* handles none as literal type ( handled as bool )
* fixes function return type

### NOTE: `clarity_convert.h` has changes on lines 93 & 106. Rest is auto formatting
### NOTE: This PR copies response structure handling from #21  